### PR TITLE
[clang][CodeGen] Fix getSizeOfUnwindException for purecap

### DIFF
--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -80,7 +80,8 @@ unsigned TargetCodeGenInfo::getSizeOfUnwindException() const {
   //   PowerPC    Linux
   //   ARM        Darwin (*not* EABI)
   //   AArch64    Linux
-  return 32;
+  unsigned PointerSize = Info->getTarget().getPointerWidth(LangAS::Default) / 8;
+  return PointerSize > 8 ? 4 * PointerSize : 32;
 }
 
 bool TargetCodeGenInfo::isNoProtoCallVariadic(const CallArgList &args,

--- a/clang/lib/CodeGen/Targets/Mips.cpp
+++ b/clang/lib/CodeGen/Targets/Mips.cpp
@@ -55,7 +55,8 @@ public:
   MIPSTargetCodeGenInfo(CodeGenTypes &CGT, bool IsO32, CodeGenModule &CGM)
       : CommonCheriTargetCodeGenInfo(
             std::make_unique<MipsABIInfo>(CGT, IsO32, CGM)),
-        SizeOfUnwindException(IsO32 ? 24 : 32) {}
+        SizeOfUnwindException(
+            IsO32 ? 24 : TargetCodeGenInfo::getSizeOfUnwindException()) {}
 
   int getDwarfEHStackPointer(CodeGen::CodeGenModule &CGM) const override {
     return 29;

--- a/clang/test/CodeGenCXX/cheri/size-of-unwind-exception.cpp
+++ b/clang/test/CodeGenCXX/cheri/size-of-unwind-exception.cpp
@@ -7,7 +7,6 @@
 // RUN:  | opt -S -passes=mem2reg | FileCheck %s --check-prefix=CHECK-RV64
 
 /// Check that we use the correct size for struct _Unwind_Exception
-/// TODO: 64-bit CHERI architectures use the wrong size
 
 void foo();
 void bar(int *&);
@@ -31,7 +30,7 @@ void bar(int *&);
 // CHECK-MIPS-NEXT:    br i1 [[MATCHES]], label [[CATCH:%.*]], label [[EH_RESUME:%.*]]
 // CHECK-MIPS:       catch:
 // CHECK-MIPS-NEXT:    [[TMP4:%.*]] = call ptr addrspace(200) @__cxa_begin_catch(ptr addrspace(200) [[TMP1]]) #[[ATTR3]]
-// CHECK-MIPS-NEXT:    [[TMP5:%.*]] = getelementptr i8, ptr addrspace(200) [[TMP1]], i32 32
+// CHECK-MIPS-NEXT:    [[TMP5:%.*]] = getelementptr i8, ptr addrspace(200) [[TMP1]], i32 64
 // CHECK-MIPS-NEXT:    invoke void @_Z3barRPi(ptr addrspace(200) noundef nonnull align 16 dereferenceable(16) [[TMP5]])
 // CHECK-MIPS-NEXT:    to label [[INVOKE_CONT2:%.*]] unwind label [[LPAD1:%.*]]
 // CHECK-MIPS:       invoke.cont2:
@@ -113,7 +112,7 @@ void bar(int *&);
 // CHECK-RV64-NEXT:    br i1 [[MATCHES]], label [[CATCH:%.*]], label [[EH_RESUME:%.*]]
 // CHECK-RV64:       catch:
 // CHECK-RV64-NEXT:    [[TMP4:%.*]] = call ptr addrspace(200) @__cxa_begin_catch(ptr addrspace(200) [[TMP1]]) #[[ATTR3]]
-// CHECK-RV64-NEXT:    [[TMP5:%.*]] = getelementptr i8, ptr addrspace(200) [[TMP1]], i32 32
+// CHECK-RV64-NEXT:    [[TMP5:%.*]] = getelementptr i8, ptr addrspace(200) [[TMP1]], i32 64
 // CHECK-RV64-NEXT:    invoke void @_Z3barRPi(ptr addrspace(200) noundef nonnull align 16 dereferenceable(16) [[TMP5]])
 // CHECK-RV64-NEXT:    to label [[INVOKE_CONT2:%.*]] unwind label [[LPAD1:%.*]]
 // CHECK-RV64:       invoke.cont2:


### PR DESCRIPTION
The exception_cleanup and private_1/private_2 members are all
capabilities in purecap ABIs rather than uint64_t (or uint32_t followed
by padding in the case of 32-bit) and so the size of the struct is
larger. On a hypothetical 128-bit architecture they would also be
128-bit integers, so generalise this code to just look at the pointer
size rather than be CHERI-specific.

Fixes: https://github.com/CTSRD-CHERI/llvm-project/issues/680
