### PR TITLE
[RISCV][CHERI] Support both Xcheri and Zcheri assembly in runtime libs.

### DIFF
--- a/compiler-rt/lib/builtins/riscv/int_mul_impl.inc
+++ b/compiler-rt/lib/builtins/riscv/int_mul_impl.inc
@@ -30,8 +30,4 @@ __mulxi3:
 	srli   a1, a1, 1
 	slli   a2, a2, 1
 	bnez   a1, .L1
-#ifdef __CHERI_PURE_CAPABILITY__
-	cret
-#else
 	ret
-#endif

--- a/libunwind/src/UnwindRegistersRestore.S
+++ b/libunwind/src/UnwindRegistersRestore.S
@@ -1308,7 +1308,7 @@ DEFINE_LIBUNWIND_FUNCTION(_ZN9libunwind15Registers_sparc6jumptoEv)
 
 .macro restore_fpr num, ctxreg
 #ifdef __CHERI_PURE_CAPABILITY__
-  cfld   f\num, (RISCV_FOFFSET + RISCV_FSIZE * \num)(c\ctxreg)
+  fld    f\num, (RISCV_FOFFSET + RISCV_FSIZE * \num)(c\ctxreg)
 #else
   FLOAD  f\num, (RISCV_FOFFSET + RISCV_FSIZE * \num)(\ctxreg)
 #endif
@@ -1316,7 +1316,7 @@ DEFINE_LIBUNWIND_FUNCTION(_ZN9libunwind15Registers_sparc6jumptoEv)
 
 .macro restore_gpr num, ctxreg
 #ifdef __CHERI_PURE_CAPABILITY__
-  clc   c\num, (__SIZEOF_CHERI_CAPABILITY__ * \num)(c\ctxreg)
+  lc    c\num, (__SIZEOF_CHERI_CAPABILITY__ * \num)(c\ctxreg)
 #else
   ILOAD x\num, (RISCV_ISIZE * \num)(\ctxreg)
 #endif
@@ -1338,7 +1338,7 @@ DEFINE_LIBUNWIND_FUNCTION(_ZN9libunwind15Registers_riscv6jumptoEv)
 
   // x0 is zero
 #ifdef __CHERI_PURE_CAPABILITY__
-  clc   c1, (__SIZEOF_CHERI_CAPABILITY__ * 0)(ca0) // restore pc into ra
+  lc       c1, (__SIZEOF_CHERI_CAPABILITY__ * 0)(ca0) // restore pc into ra
 #else
   ILOAD    x1, (RISCV_ISIZE * 0)(a0) // restore pc into ra
 #endif
@@ -1351,11 +1351,7 @@ DEFINE_LIBUNWIND_FUNCTION(_ZN9libunwind15Registers_riscv6jumptoEv)
   .endr
   restore_gpr 10, a0  // restore a0
 
-#ifdef __CHERI_PURE_CAPABILITY__
-  cret          // jump to cra
-#else
   ret           // jump to ra
-#endif
 END_LIBUNWIND_FUNCTION(_ZN9libunwind15Registers_riscv6jumptoEv)
 
 #elif defined(__s390x__)

--- a/libunwind/src/UnwindRegistersSave.S
+++ b/libunwind/src/UnwindRegistersSave.S
@@ -1237,7 +1237,7 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 
 .macro save_fpr num, ctxreg
 #ifdef __CHERI_PURE_CAPABILITY__
-  cfsd   f\num, (RISCV_FOFFSET + RISCV_FSIZE * \num)(c\ctxreg)
+  fsd    f\num, (RISCV_FOFFSET + RISCV_FSIZE * \num)(c\ctxreg)
 #else
   FSTORE f\num, (RISCV_FOFFSET + RISCV_FSIZE * \num)(\ctxreg)
 #endif
@@ -1245,7 +1245,7 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 
 .macro save_gpr num, ctxreg
 #ifdef __CHERI_PURE_CAPABILITY__
-  csc   c\num, (__SIZEOF_CHERI_CAPABILITY__ * \num)(c\ctxreg)
+  sc     c\num, (__SIZEOF_CHERI_CAPABILITY__ * \num)(c\ctxreg)
 #else
   ISTORE x\num, (RISCV_ISIZE * \num)(\ctxreg)
 #endif
@@ -1259,7 +1259,7 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 #
 DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 #ifdef __CHERI_PURE_CAPABILITY__
-  csc   c1, (__SIZEOF_CHERI_CAPABILITY__ * 0)(ca0) // store ra as pc
+  sc        c1, (__SIZEOF_CHERI_CAPABILITY__ * 0)(ca0) // store ra as pc
 #else
   ISTORE    x1, (RISCV_ISIZE * 0)(a0) // store ra as pc
 #endif
@@ -1274,11 +1274,7 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 # endif
 
   li     a0, 0  // return UNW_ESUCCESS
-#ifdef __CHERI_PURE_CAPABILITY__
-  cret          // jump to cra
-#else
-  ret           // jump to ra
-#endif
+  ret          // jump to ra
 END_LIBUNWIND_FUNCTION(__unw_getcontext)
 
 #elif defined(__s390x__)


### PR DESCRIPTION
This is in preparation for standard CHERI encodings. Use the appropriate instruction mnemonics in compiler-rt and libunwind, depending on __riscv_xcheri.