### PR TITLE
[ELF][RISCV] Handle R_RISCV_FUNC_RELATIVE in getImplicitAddend

### DIFF
--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -208,6 +208,7 @@ int64_t RISCV::getImplicitAddend(const uint8_t *buf, RelType type) const {
     return read64le(buf);
   case R_RISCV_RELATIVE:
   case R_RISCV_IRELATIVE:
+  case R_RISCV_FUNC_RELATIVE:
     return config->is64 ? read64le(buf) : read32le(buf);
   case R_RISCV_NONE:
   case R_RISCV_JUMP_SLOT:


### PR DESCRIPTION
This should have been part of commit 2d52aa89a7bed25c75e6b2e82061f9641e11bf3c