### PR TITLE
[clang][test] Remove #ifndef __CHERI_PURE_CAPABILITY__ from a test

### DIFF
--- a/clang/test/CodeGenCXX/temporaries.cpp
+++ b/clang/test/CodeGenCXX/temporaries.cpp
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -emit-llvm %s -o - -triple=x86_64-apple-darwin9 -std=c++11 -fno-delete-null-pointer-checks | FileCheck %s -check-prefixes=CHECK,NULL-VALID,CHECK-CXX11
 
 
-// RUN: %cheri_cc1 -mllvm -cheri-cap-table-abi=pcrel -fno-rtti -emit-llvm %s -o -  -target-abi purecap -std=c++11 | FileCheck %s -check-prefixes=CHERI
+// RUN: %cheri_purecap_cc1 -emit-llvm %s -o - -std=c++11 | FileCheck %s -check-prefixes=CHERI
 // Check that there are no pointers without addresspace(200)*
 // CHERI-NOT: {{[^)]\*}}
 
@@ -42,10 +42,8 @@ namespace PR20227 {
   A &&a = dynamic_cast<A&&>(A{});
   // CHECK: @_ZGRN7PR202271aE_ = internal global
 
-#ifndef __CHERI_PURE_CAPABILITY__
   B &&b = dynamic_cast<C&&>(dynamic_cast<B&&>(C{}));
   // CHECK: @_ZGRN7PR202271bE_ = internal global
-#endif
 
   B &&c = static_cast<C&&>(static_cast<B&&>(C{}));
   // CHECK: @_ZGRN7PR202271cE_ = internal global
@@ -380,8 +378,6 @@ namespace UserConvertToValue {
   }
 }
 
-#ifndef __CHERI_PURE_CAPABILITY__
-// XXXAR: TODO: fix pointers to members so we no longer invoke @llvm.memcpy.p200i8.p0i8.i64
 namespace PR7556 {
   struct A { ~A(); };
   struct B { int i; ~B(); };
@@ -399,7 +395,6 @@ namespace PR7556 {
     // CHECK-NEXT: ret void
   }
 }
-#endif
 
 namespace Elision {
   struct A {


### PR DESCRIPTION
RTTI has worked for a while, as do pointers to members. Whilst here make
the RUN line a bit less ugly beyond just removing the -fno-rtti to allow
dynamic_cast.
