### PR TITLE
Add a CI job to build a docker image with the compiler installed

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -110,5 +110,4 @@ jobs:
 
     - name: Push Docker Image
       run: |
-        echo "Pushing $IMAGE_ID:$TAG_NAME"
         docker push $IMAGE_ID:$TAG_NAME


### PR DESCRIPTION
This takes a bit over an hour to run with the targets limited to RISC-V+Host and it doesn't run the tests yet.
This should allow reusing the compiler in other GitHub actions.

Example run: https://github.com/arichardson/llvm-project/actions/runs/19867025000/job/56932513168 and the image from that can be fetched as `ghcr.io/arichardson/llvm-project:github-actions-test`