### PR TITLE
CheriRangeChecker: C++20 aggregate type rules

### DIFF
--- a/llvm/lib/Target/Mips/CheriRangeChecker.cpp
+++ b/llvm/lib/Target/Mips/CheriRangeChecker.cpp
@@ -30,12 +30,10 @@ namespace {
 // Operands for an allocation.  Either one or two integers (constant or
 // variable).  If there are two, then they must be multiplied together.
 struct ValueSource {
-  ValueSource() = default;
   Value *Base = nullptr;
   int64_t Offset = 0;
 };
 struct AllocOperands {
-  AllocOperands() = default;
   Value *Size = nullptr;
   Value *SizeMultiplier = nullptr;
   ValueSource ValueSrc;


### PR DESCRIPTION
Remove the user-declared (but not user-provided) explicitly-defaulted (but not explicit) default constructors from ValueSource and AllocOperands so that these types are considered to be aggregate types under both C++11 and C++20.  Relative to C++11, C++20 additionally precludes user-declared constructors on aggregates.

Fixes, among others, the following build errors (where the code uses aggregate initialization syntax for these types):

.../llvm/lib/Target/Mips/CheriRangeChecker.cpp:72:12: error: no matching constructor for initialization of 'ValueSource'
   72 |     return ValueSource{Src, Offset};
.../llvm/lib/Target/Mips/CheriRangeChecker.cpp:93:16: error: no matching constructor for initialization of 'AllocOperands'
   93 |         return AllocOperands{Malloc->getArgOperand(0), nullptr, Src,