### PR TITLE
[NFC][ELF][CHERI] Fix a set but not used warning

### DIFF
--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -494,7 +494,7 @@ void CheriCapRelocsSection::writeToImpl(uint8_t *buf) {
     uint64_t targetVA;
     bool isCode = reloc.isCode;
     if (Symbol *s = dyn_cast<Symbol *>(realTarget.symOrSec))
-      targetVA = realTarget.sym()->getVA(0);
+      targetVA = s->getVA(0);
     else {
       InputSectionBase *isec = cast<InputSectionBase *>(realTarget.symOrSec);
       targetVA = isec->getVA(0);


### PR DESCRIPTION
lld/ELF/Arch/Cheri.cpp:496:17: warning: variable 's' set but not used [-Wunused-but-set-variable]
  496 |     if (Symbol *s = dyn_cast<Symbol *>(realTarget.symOrSec))
      |                 ^

Fixes: b9963faf27be ("[ELF][CHERI] Add new getTargetType to separate encoding from classification")