### PR TITLE
[SelectionDAG] Allow fat pointer SETCC to be folded like integer SETCC

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -2501,11 +2501,12 @@ SDValue SelectionDAG::FoldSetCC(EVT VT, SDValue N1, SDValue N2,
   case ISD::SETUO:
   case ISD::SETUEQ:
   case ISD::SETUNE:
-    assert(!OpVT.isInteger() && "Illegal setcc for integer!");
+    assert(!OpVT.isInteger() && !OpVT.isFatPointer() &&
+           "Illegal setcc for integer or pointer!");
     break;
   }
 
-  if (OpVT.isInteger()) {
+  if (OpVT.isInteger() || OpVT.isFatPointer()) {
     // For EQ and NE, we can always pick a value for the undef to make the
     // predicate pass or fail, so we can return undef.
     // Matches behavior in llvm::ConstantFoldCompareInstruction.

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -5045,7 +5045,8 @@ SDValue TargetLowering::SimplifySetCC(EVT VT, SDValue N0, SDValue N1,
     // The sext(setcc()) => setcc() optimization relies on the appropriate
     // constant being emitted.
     assert(!N0.getValueType().isInteger() &&
-           "Integer types should be handled by FoldSetCC");
+           !N0.getValueType().isFatPointer() &&
+           "Integer and pointer types should be handled by FoldSetCC");
 
     bool EqTrue = ISD::isTrueWhenEqual(Cond);
     unsigned UOF = ISD::getUnorderedFlavor(Cond);

--- a/llvm/test/CodeGen/CHERI-Generic/Inputs/cheri-pointer-comparison.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/Inputs/cheri-pointer-comparison.ll
@@ -98,6 +98,66 @@ define i32 @sle(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
   ret i32 %conv
 }
 
+define i32 @eq_same(i8 addrspace(200)* %a) nounwind {
+  %cmp = icmp eq i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ne_same(i8 addrspace(200)* %a) nounwind {
+  %cmp = icmp ne i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ugt_same(i8 addrspace(200)* %a) nounwind {
+  %cmp = icmp ugt i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @uge_same(i8 addrspace(200)* %a) nounwind {
+  %cmp = icmp uge i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ult_same(i8 addrspace(200)* %a) nounwind {
+  %cmp = icmp ult i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ule_same(i8 addrspace(200)* %a) nounwind {
+  %cmp = icmp ule i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @sgt_same(i8 addrspace(200)* %a) nounwind {
+  %cmp = icmp sgt i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @sge_same(i8 addrspace(200)* %a) nounwind {
+  %cmp = icmp sge i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @slt_same(i8 addrspace(200)* %a) nounwind {
+  %cmp = icmp slt i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @sle_same(i8 addrspace(200)* %a) nounwind {
+  %cmp = icmp sle i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
 define i32 @eq_null(i8 addrspace(200)* %a) nounwind {
   %cmp = icmp eq i8 addrspace(200)* %a, null
   %conv = zext i1 %cmp to i32

--- a/llvm/test/CodeGen/CHERI-Generic/MIPS/cheri-pointer-comparison.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/MIPS/cheri-pointer-comparison.ll
@@ -190,6 +190,156 @@ define i32 @sle(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
   ret i32 %conv
 }
 
+define i32 @eq_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: eq_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    jr $ra
+; HYBRID-NEXT:    addiu $2, $zero, 1
+;
+; PURECAP-LABEL: eq_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    cjr $c17
+; PURECAP-NEXT:    addiu $2, $zero, 1
+  %cmp = icmp eq i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ne_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: ne_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    jr $ra
+; HYBRID-NEXT:    addiu $2, $zero, 0
+;
+; PURECAP-LABEL: ne_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    cjr $c17
+; PURECAP-NEXT:    addiu $2, $zero, 0
+  %cmp = icmp ne i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ugt_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: ugt_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    jr $ra
+; HYBRID-NEXT:    addiu $2, $zero, 0
+;
+; PURECAP-LABEL: ugt_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    cjr $c17
+; PURECAP-NEXT:    addiu $2, $zero, 0
+  %cmp = icmp ugt i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @uge_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: uge_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    jr $ra
+; HYBRID-NEXT:    addiu $2, $zero, 1
+;
+; PURECAP-LABEL: uge_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    cjr $c17
+; PURECAP-NEXT:    addiu $2, $zero, 1
+  %cmp = icmp uge i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ult_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: ult_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    jr $ra
+; HYBRID-NEXT:    addiu $2, $zero, 0
+;
+; PURECAP-LABEL: ult_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    cjr $c17
+; PURECAP-NEXT:    addiu $2, $zero, 0
+  %cmp = icmp ult i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ule_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: ule_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    jr $ra
+; HYBRID-NEXT:    addiu $2, $zero, 1
+;
+; PURECAP-LABEL: ule_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    cjr $c17
+; PURECAP-NEXT:    addiu $2, $zero, 1
+  %cmp = icmp ule i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @sgt_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: sgt_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    jr $ra
+; HYBRID-NEXT:    addiu $2, $zero, 0
+;
+; PURECAP-LABEL: sgt_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    cjr $c17
+; PURECAP-NEXT:    addiu $2, $zero, 0
+  %cmp = icmp sgt i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @sge_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: sge_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    jr $ra
+; HYBRID-NEXT:    addiu $2, $zero, 1
+;
+; PURECAP-LABEL: sge_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    cjr $c17
+; PURECAP-NEXT:    addiu $2, $zero, 1
+  %cmp = icmp sge i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @slt_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: slt_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    jr $ra
+; HYBRID-NEXT:    addiu $2, $zero, 0
+;
+; PURECAP-LABEL: slt_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    cjr $c17
+; PURECAP-NEXT:    addiu $2, $zero, 0
+  %cmp = icmp slt i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @sle_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: sle_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    jr $ra
+; HYBRID-NEXT:    addiu $2, $zero, 1
+;
+; PURECAP-LABEL: sle_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    cjr $c17
+; PURECAP-NEXT:    addiu $2, $zero, 1
+  %cmp = icmp sle i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
 define i32 @eq_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: eq_null:
 ; HYBRID:       # %bb.0:
@@ -732,7 +882,7 @@ define i32 @branch_eq(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_eq)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cne $2, $c3, $c4
-; HYBRID-NEXT:    beqz $2, .LBB40_2
+; HYBRID-NEXT:    beqz $2, .LBB50_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_eq)))
 ; HYBRID-NEXT:  # %bb.1: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
@@ -744,7 +894,7 @@ define i32 @branch_eq(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB40_2: # %if.then
+; HYBRID-NEXT:  .LBB50_2: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp1, R_MIPS_JALR, func1
 ; HYBRID-NEXT:  .Ltmp1:
@@ -763,7 +913,7 @@ define i32 @branch_eq(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    beqz $1, .LBB40_2
+; PURECAP-NEXT:    beqz $1, .LBB50_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
@@ -772,7 +922,7 @@ define i32 @branch_eq(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB40_2: # %if.then
+; PURECAP-NEXT:  .LBB50_2: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -799,7 +949,7 @@ define i32 @branch_ne(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_ne)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    ceq $2, $c3, $c4
-; HYBRID-NEXT:    bnez $2, .LBB41_2
+; HYBRID-NEXT:    bnez $2, .LBB51_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_ne)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -811,7 +961,7 @@ define i32 @branch_ne(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB41_2: # %if.end
+; HYBRID-NEXT:  .LBB51_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp3, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp3:
@@ -830,7 +980,7 @@ define i32 @branch_ne(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB41_2
+; PURECAP-NEXT:    bnez $1, .LBB51_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -839,7 +989,7 @@ define i32 @branch_ne(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB41_2: # %if.end
+; PURECAP-NEXT:  .LBB51_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -866,7 +1016,7 @@ define i32 @branch_ugt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_ugt)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cleu $2, $c3, $c4
-; HYBRID-NEXT:    bnez $2, .LBB42_2
+; HYBRID-NEXT:    bnez $2, .LBB52_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_ugt)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -878,7 +1028,7 @@ define i32 @branch_ugt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB42_2: # %if.end
+; HYBRID-NEXT:  .LBB52_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp5, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp5:
@@ -897,7 +1047,7 @@ define i32 @branch_ugt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB42_2
+; PURECAP-NEXT:    bnez $1, .LBB52_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -906,7 +1056,7 @@ define i32 @branch_ugt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB42_2: # %if.end
+; PURECAP-NEXT:  .LBB52_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -933,7 +1083,7 @@ define i32 @branch_uge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_uge)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cltu $2, $c3, $c4
-; HYBRID-NEXT:    bnez $2, .LBB43_2
+; HYBRID-NEXT:    bnez $2, .LBB53_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_uge)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -945,7 +1095,7 @@ define i32 @branch_uge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB43_2: # %if.end
+; HYBRID-NEXT:  .LBB53_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp7, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp7:
@@ -964,7 +1114,7 @@ define i32 @branch_uge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB43_2
+; PURECAP-NEXT:    bnez $1, .LBB53_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -973,7 +1123,7 @@ define i32 @branch_uge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB43_2: # %if.end
+; PURECAP-NEXT:  .LBB53_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1000,7 +1150,7 @@ define i32 @branch_ult(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_ult)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cleu $2, $c4, $c3
-; HYBRID-NEXT:    bnez $2, .LBB44_2
+; HYBRID-NEXT:    bnez $2, .LBB54_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_ult)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1012,7 +1162,7 @@ define i32 @branch_ult(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB44_2: # %if.end
+; HYBRID-NEXT:  .LBB54_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp9, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp9:
@@ -1031,7 +1181,7 @@ define i32 @branch_ult(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB44_2
+; PURECAP-NEXT:    bnez $1, .LBB54_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1040,7 +1190,7 @@ define i32 @branch_ult(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB44_2: # %if.end
+; PURECAP-NEXT:  .LBB54_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1067,7 +1217,7 @@ define i32 @branch_ule(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_ule)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cltu $2, $c4, $c3
-; HYBRID-NEXT:    bnez $2, .LBB45_2
+; HYBRID-NEXT:    bnez $2, .LBB55_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_ule)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1079,7 +1229,7 @@ define i32 @branch_ule(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB45_2: # %if.end
+; HYBRID-NEXT:  .LBB55_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp11, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp11:
@@ -1098,7 +1248,7 @@ define i32 @branch_ule(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB45_2
+; PURECAP-NEXT:    bnez $1, .LBB55_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1107,7 +1257,7 @@ define i32 @branch_ule(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB45_2: # %if.end
+; PURECAP-NEXT:  .LBB55_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1134,7 +1284,7 @@ define i32 @branch_sgt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_sgt)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cle $2, $c3, $c4
-; HYBRID-NEXT:    bnez $2, .LBB46_2
+; HYBRID-NEXT:    bnez $2, .LBB56_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_sgt)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1146,7 +1296,7 @@ define i32 @branch_sgt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB46_2: # %if.end
+; HYBRID-NEXT:  .LBB56_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp13, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp13:
@@ -1165,7 +1315,7 @@ define i32 @branch_sgt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB46_2
+; PURECAP-NEXT:    bnez $1, .LBB56_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1174,7 +1324,7 @@ define i32 @branch_sgt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB46_2: # %if.end
+; PURECAP-NEXT:  .LBB56_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1201,7 +1351,7 @@ define i32 @branch_sge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_sge)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    clt $2, $c3, $c4
-; HYBRID-NEXT:    bnez $2, .LBB47_2
+; HYBRID-NEXT:    bnez $2, .LBB57_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_sge)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1213,7 +1363,7 @@ define i32 @branch_sge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB47_2: # %if.end
+; HYBRID-NEXT:  .LBB57_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp15, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp15:
@@ -1232,7 +1382,7 @@ define i32 @branch_sge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB47_2
+; PURECAP-NEXT:    bnez $1, .LBB57_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1241,7 +1391,7 @@ define i32 @branch_sge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB47_2: # %if.end
+; PURECAP-NEXT:  .LBB57_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1268,7 +1418,7 @@ define i32 @branch_slt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_slt)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cle $2, $c4, $c3
-; HYBRID-NEXT:    bnez $2, .LBB48_2
+; HYBRID-NEXT:    bnez $2, .LBB58_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_slt)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1280,7 +1430,7 @@ define i32 @branch_slt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB48_2: # %if.end
+; HYBRID-NEXT:  .LBB58_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp17, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp17:
@@ -1299,7 +1449,7 @@ define i32 @branch_slt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB48_2
+; PURECAP-NEXT:    bnez $1, .LBB58_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1308,7 +1458,7 @@ define i32 @branch_slt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB48_2: # %if.end
+; PURECAP-NEXT:  .LBB58_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1335,7 +1485,7 @@ define i32 @branch_sle(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_sle)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    clt $2, $c4, $c3
-; HYBRID-NEXT:    bnez $2, .LBB49_2
+; HYBRID-NEXT:    bnez $2, .LBB59_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_sle)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1347,7 +1497,7 @@ define i32 @branch_sle(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB49_2: # %if.end
+; HYBRID-NEXT:  .LBB59_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp19, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp19:
@@ -1366,7 +1516,7 @@ define i32 @branch_sle(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB49_2
+; PURECAP-NEXT:    bnez $1, .LBB59_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1375,7 +1525,7 @@ define i32 @branch_sle(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB49_2: # %if.end
+; PURECAP-NEXT:  .LBB59_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1401,7 +1551,7 @@ define i32 @branch_eq_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    sd $gp, 0($sp) # 8-byte Folded Spill
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_eq_null)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
-; HYBRID-NEXT:    cbez $c3, .LBB50_2
+; HYBRID-NEXT:    cbez $c3, .LBB60_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_eq_null)))
 ; HYBRID-NEXT:  # %bb.1: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
@@ -1413,7 +1563,7 @@ define i32 @branch_eq_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB50_2: # %if.then
+; HYBRID-NEXT:  .LBB60_2: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp21, R_MIPS_JALR, func1
 ; HYBRID-NEXT:  .Ltmp21:
@@ -1431,7 +1581,7 @@ define i32 @branch_eq_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    lui $1, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $1, $1, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $1
-; PURECAP-NEXT:    cbez $c3, .LBB50_2
+; PURECAP-NEXT:    cbez $c3, .LBB60_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
@@ -1440,7 +1590,7 @@ define i32 @branch_eq_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB50_2: # %if.then
+; PURECAP-NEXT:  .LBB60_2: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1466,7 +1616,7 @@ define i32 @branch_ne_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    sd $gp, 0($sp) # 8-byte Folded Spill
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_ne_null)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
-; HYBRID-NEXT:    cbez $c3, .LBB51_2
+; HYBRID-NEXT:    cbez $c3, .LBB61_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_ne_null)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1478,7 +1628,7 @@ define i32 @branch_ne_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB51_2: # %if.end
+; HYBRID-NEXT:  .LBB61_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp23, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp23:
@@ -1496,7 +1646,7 @@ define i32 @branch_ne_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    lui $1, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $1, $1, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $1
-; PURECAP-NEXT:    cbez $c3, .LBB51_2
+; PURECAP-NEXT:    cbez $c3, .LBB61_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1505,7 +1655,7 @@ define i32 @branch_ne_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB51_2: # %if.end
+; PURECAP-NEXT:  .LBB61_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1532,7 +1682,7 @@ define i32 @branch_ugt_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_ugt_null)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cleu $2, $c3, $cnull
-; HYBRID-NEXT:    bnez $2, .LBB52_2
+; HYBRID-NEXT:    bnez $2, .LBB62_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_ugt_null)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1544,7 +1694,7 @@ define i32 @branch_ugt_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB52_2: # %if.end
+; HYBRID-NEXT:  .LBB62_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp25, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp25:
@@ -1563,7 +1713,7 @@ define i32 @branch_ugt_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB52_2
+; PURECAP-NEXT:    bnez $1, .LBB62_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1572,7 +1722,7 @@ define i32 @branch_ugt_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB52_2: # %if.end
+; PURECAP-NEXT:  .LBB62_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1599,7 +1749,7 @@ define i32 @branch_uge_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_uge_null)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cltu $2, $c3, $cnull
-; HYBRID-NEXT:    bnez $2, .LBB53_2
+; HYBRID-NEXT:    bnez $2, .LBB63_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_uge_null)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1611,7 +1761,7 @@ define i32 @branch_uge_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB53_2: # %if.end
+; HYBRID-NEXT:  .LBB63_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp27, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp27:
@@ -1630,7 +1780,7 @@ define i32 @branch_uge_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB53_2
+; PURECAP-NEXT:    bnez $1, .LBB63_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1639,7 +1789,7 @@ define i32 @branch_uge_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB53_2: # %if.end
+; PURECAP-NEXT:  .LBB63_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1666,7 +1816,7 @@ define i32 @branch_ult_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_ult_null)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cleu $2, $cnull, $c3
-; HYBRID-NEXT:    bnez $2, .LBB54_2
+; HYBRID-NEXT:    bnez $2, .LBB64_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_ult_null)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1678,7 +1828,7 @@ define i32 @branch_ult_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB54_2: # %if.end
+; HYBRID-NEXT:  .LBB64_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp29, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp29:
@@ -1697,7 +1847,7 @@ define i32 @branch_ult_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB54_2
+; PURECAP-NEXT:    bnez $1, .LBB64_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1706,7 +1856,7 @@ define i32 @branch_ult_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB54_2: # %if.end
+; PURECAP-NEXT:  .LBB64_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1733,7 +1883,7 @@ define i32 @branch_ule_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_ule_null)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cltu $2, $cnull, $c3
-; HYBRID-NEXT:    bnez $2, .LBB55_2
+; HYBRID-NEXT:    bnez $2, .LBB65_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_ule_null)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1745,7 +1895,7 @@ define i32 @branch_ule_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB55_2: # %if.end
+; HYBRID-NEXT:  .LBB65_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp31, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp31:
@@ -1764,7 +1914,7 @@ define i32 @branch_ule_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB55_2
+; PURECAP-NEXT:    bnez $1, .LBB65_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1773,7 +1923,7 @@ define i32 @branch_ule_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB55_2: # %if.end
+; PURECAP-NEXT:  .LBB65_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1800,7 +1950,7 @@ define i32 @branch_sgt_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_sgt_null)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cle $2, $c3, $cnull
-; HYBRID-NEXT:    bnez $2, .LBB56_2
+; HYBRID-NEXT:    bnez $2, .LBB66_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_sgt_null)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1812,7 +1962,7 @@ define i32 @branch_sgt_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB56_2: # %if.end
+; HYBRID-NEXT:  .LBB66_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp33, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp33:
@@ -1831,7 +1981,7 @@ define i32 @branch_sgt_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB56_2
+; PURECAP-NEXT:    bnez $1, .LBB66_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1840,7 +1990,7 @@ define i32 @branch_sgt_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB56_2: # %if.end
+; PURECAP-NEXT:  .LBB66_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1867,7 +2017,7 @@ define i32 @branch_sge_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_sge_null)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    clt $2, $c3, $cnull
-; HYBRID-NEXT:    bnez $2, .LBB57_2
+; HYBRID-NEXT:    bnez $2, .LBB67_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_sge_null)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1879,7 +2029,7 @@ define i32 @branch_sge_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB57_2: # %if.end
+; HYBRID-NEXT:  .LBB67_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp35, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp35:
@@ -1898,7 +2048,7 @@ define i32 @branch_sge_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB57_2
+; PURECAP-NEXT:    bnez $1, .LBB67_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1907,7 +2057,7 @@ define i32 @branch_sge_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB57_2: # %if.end
+; PURECAP-NEXT:  .LBB67_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -1934,7 +2084,7 @@ define i32 @branch_slt_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_slt_null)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    cle $2, $cnull, $c3
-; HYBRID-NEXT:    bnez $2, .LBB58_2
+; HYBRID-NEXT:    bnez $2, .LBB68_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_slt_null)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -1946,7 +2096,7 @@ define i32 @branch_slt_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB58_2: # %if.end
+; HYBRID-NEXT:  .LBB68_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp37, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp37:
@@ -1965,7 +2115,7 @@ define i32 @branch_slt_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB58_2
+; PURECAP-NEXT:    bnez $1, .LBB68_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -1974,7 +2124,7 @@ define i32 @branch_slt_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB58_2: # %if.end
+; PURECAP-NEXT:  .LBB68_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop
@@ -2001,7 +2151,7 @@ define i32 @branch_sle_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    lui $1, %hi(%neg(%gp_rel(branch_sle_null)))
 ; HYBRID-NEXT:    daddu $1, $1, $25
 ; HYBRID-NEXT:    clt $2, $cnull, $c3
-; HYBRID-NEXT:    bnez $2, .LBB59_2
+; HYBRID-NEXT:    bnez $2, .LBB69_2
 ; HYBRID-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(branch_sle_null)))
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    ld $25, %call16(func1)($gp)
@@ -2013,7 +2163,7 @@ define i32 @branch_sle_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
 ; HYBRID-NEXT:    jr $ra
 ; HYBRID-NEXT:    daddiu $sp, $sp, 16
-; HYBRID-NEXT:  .LBB59_2: # %if.end
+; HYBRID-NEXT:  .LBB69_2: # %if.end
 ; HYBRID-NEXT:    ld $25, %call16(func2)($gp)
 ; HYBRID-NEXT:    .reloc .Ltmp39, R_MIPS_JALR, func2
 ; HYBRID-NEXT:  .Ltmp39:
@@ -2032,7 +2182,7 @@ define i32 @branch_sle_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    lui $2, %pcrel_hi(_CHERI_CAPABILITY_TABLE_-8)
 ; PURECAP-NEXT:    daddiu $2, $2, %pcrel_lo(_CHERI_CAPABILITY_TABLE_-4)
 ; PURECAP-NEXT:    cgetpccincoffset $c1, $2
-; PURECAP-NEXT:    bnez $1, .LBB59_2
+; PURECAP-NEXT:    bnez $1, .LBB69_2
 ; PURECAP-NEXT:    nop
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func1)($c1)
@@ -2041,7 +2191,7 @@ define i32 @branch_sle_null(i8 addrspace(200)* %a) nounwind {
 ; PURECAP-NEXT:    clc $c17, $zero, 0($c11) # 16-byte Folded Reload
 ; PURECAP-NEXT:    cjr $c17
 ; PURECAP-NEXT:    cincoffset $c11, $c11, 16
-; PURECAP-NEXT:  .LBB59_2: # %if.end
+; PURECAP-NEXT:  .LBB69_2: # %if.end
 ; PURECAP-NEXT:    clcbi $c12, %capcall20(func2)($c1)
 ; PURECAP-NEXT:    cjalr $c12, $c17
 ; PURECAP-NEXT:    nop

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV32/cheri-pointer-comparison.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV32/cheri-pointer-comparison.ll
@@ -202,6 +202,156 @@ define i32 @sle(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
   ret i32 %conv
 }
 
+define i32 @eq_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: eq_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 1
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: eq_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 1
+; PURECAP-NEXT:    ret
+  %cmp = icmp eq i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ne_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: ne_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 0
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: ne_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 0
+; PURECAP-NEXT:    ret
+  %cmp = icmp ne i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ugt_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: ugt_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 0
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: ugt_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 0
+; PURECAP-NEXT:    ret
+  %cmp = icmp ugt i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @uge_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: uge_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 1
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: uge_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 1
+; PURECAP-NEXT:    ret
+  %cmp = icmp uge i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ult_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: ult_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 0
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: ult_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 0
+; PURECAP-NEXT:    ret
+  %cmp = icmp ult i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ule_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: ule_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 1
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: ule_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 1
+; PURECAP-NEXT:    ret
+  %cmp = icmp ule i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @sgt_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: sgt_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 0
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: sgt_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 0
+; PURECAP-NEXT:    ret
+  %cmp = icmp sgt i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @sge_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: sge_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 1
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: sge_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 1
+; PURECAP-NEXT:    ret
+  %cmp = icmp sge i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @slt_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: slt_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 0
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: slt_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 0
+; PURECAP-NEXT:    ret
+  %cmp = icmp slt i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @sle_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: sle_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 1
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: sle_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 1
+; PURECAP-NEXT:    ret
+  %cmp = icmp sle i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
 define i32 @eq_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: eq_null:
 ; HYBRID:       # %bb.0:
@@ -363,18 +513,18 @@ define i32 @sle_null(i8 addrspace(200)* %a) nounwind {
 define i8 addrspace(200)* @select_eq(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_eq:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    beq a0, a1, .LBB20_2
+; HYBRID-NEXT:    beq a0, a1, .LBB30_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB20_2:
+; HYBRID-NEXT:  .LBB30_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_eq:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    beq a0, a1, .LBB20_2
+; PURECAP-NEXT:    beq a0, a1, .LBB30_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB20_2:
+; PURECAP-NEXT:  .LBB30_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp eq i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -384,18 +534,18 @@ define i8 addrspace(200)* @select_eq(i8 addrspace(200)* %a, i8 addrspace(200)* %
 define i8 addrspace(200)* @select_ne(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ne:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bne a0, a1, .LBB21_2
+; HYBRID-NEXT:    bne a0, a1, .LBB31_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB21_2:
+; HYBRID-NEXT:  .LBB31_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ne:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bne a0, a1, .LBB21_2
+; PURECAP-NEXT:    bne a0, a1, .LBB31_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB21_2:
+; PURECAP-NEXT:  .LBB31_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ne i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -405,18 +555,18 @@ define i8 addrspace(200)* @select_ne(i8 addrspace(200)* %a, i8 addrspace(200)* %
 define i8 addrspace(200)* @select_ugt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ugt:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bltu a1, a0, .LBB22_2
+; HYBRID-NEXT:    bltu a1, a0, .LBB32_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB22_2:
+; HYBRID-NEXT:  .LBB32_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ugt:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bltu a1, a0, .LBB22_2
+; PURECAP-NEXT:    bltu a1, a0, .LBB32_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB22_2:
+; PURECAP-NEXT:  .LBB32_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ugt i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -426,18 +576,18 @@ define i8 addrspace(200)* @select_ugt(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_uge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_uge:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bgeu a0, a1, .LBB23_2
+; HYBRID-NEXT:    bgeu a0, a1, .LBB33_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB23_2:
+; HYBRID-NEXT:  .LBB33_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_uge:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bgeu a0, a1, .LBB23_2
+; PURECAP-NEXT:    bgeu a0, a1, .LBB33_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB23_2:
+; PURECAP-NEXT:  .LBB33_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp uge i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -447,18 +597,18 @@ define i8 addrspace(200)* @select_uge(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_ult(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ult:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bltu a0, a1, .LBB24_2
+; HYBRID-NEXT:    bltu a0, a1, .LBB34_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB24_2:
+; HYBRID-NEXT:  .LBB34_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ult:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bltu a0, a1, .LBB24_2
+; PURECAP-NEXT:    bltu a0, a1, .LBB34_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB24_2:
+; PURECAP-NEXT:  .LBB34_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ult i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -468,18 +618,18 @@ define i8 addrspace(200)* @select_ult(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_ule(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ule:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bgeu a1, a0, .LBB25_2
+; HYBRID-NEXT:    bgeu a1, a0, .LBB35_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB25_2:
+; HYBRID-NEXT:  .LBB35_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ule:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bgeu a1, a0, .LBB25_2
+; PURECAP-NEXT:    bgeu a1, a0, .LBB35_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB25_2:
+; PURECAP-NEXT:  .LBB35_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ule i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -489,18 +639,18 @@ define i8 addrspace(200)* @select_ule(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_sgt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_sgt:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    blt a1, a0, .LBB26_2
+; HYBRID-NEXT:    blt a1, a0, .LBB36_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB26_2:
+; HYBRID-NEXT:  .LBB36_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_sgt:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    blt a1, a0, .LBB26_2
+; PURECAP-NEXT:    blt a1, a0, .LBB36_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB26_2:
+; PURECAP-NEXT:  .LBB36_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp sgt i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -510,18 +660,18 @@ define i8 addrspace(200)* @select_sgt(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_sge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_sge:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bge a0, a1, .LBB27_2
+; HYBRID-NEXT:    bge a0, a1, .LBB37_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB27_2:
+; HYBRID-NEXT:  .LBB37_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_sge:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bge a0, a1, .LBB27_2
+; PURECAP-NEXT:    bge a0, a1, .LBB37_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB27_2:
+; PURECAP-NEXT:  .LBB37_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp sge i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -531,18 +681,18 @@ define i8 addrspace(200)* @select_sge(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_slt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_slt:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    blt a0, a1, .LBB28_2
+; HYBRID-NEXT:    blt a0, a1, .LBB38_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB28_2:
+; HYBRID-NEXT:  .LBB38_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_slt:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    blt a0, a1, .LBB28_2
+; PURECAP-NEXT:    blt a0, a1, .LBB38_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB28_2:
+; PURECAP-NEXT:  .LBB38_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp slt i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -552,18 +702,18 @@ define i8 addrspace(200)* @select_slt(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_sle(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_sle:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bge a1, a0, .LBB29_2
+; HYBRID-NEXT:    bge a1, a0, .LBB39_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB29_2:
+; HYBRID-NEXT:  .LBB39_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_sle:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bge a1, a0, .LBB29_2
+; PURECAP-NEXT:    bge a1, a0, .LBB39_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB29_2:
+; PURECAP-NEXT:  .LBB39_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp sle i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -573,18 +723,18 @@ define i8 addrspace(200)* @select_sle(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_eq_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_eq_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    beqz a0, .LBB30_2
+; HYBRID-NEXT:    beqz a0, .LBB40_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB30_2:
+; HYBRID-NEXT:  .LBB40_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_eq_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    beqz a0, .LBB30_2
+; PURECAP-NEXT:    beqz a0, .LBB40_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB30_2:
+; PURECAP-NEXT:  .LBB40_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp eq i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -594,18 +744,18 @@ define i8 addrspace(200)* @select_eq_null(i8 addrspace(200)* %a, i8 addrspace(20
 define i8 addrspace(200)* @select_ne_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ne_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bnez a0, .LBB31_2
+; HYBRID-NEXT:    bnez a0, .LBB41_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB31_2:
+; HYBRID-NEXT:  .LBB41_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ne_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bnez a0, .LBB31_2
+; PURECAP-NEXT:    bnez a0, .LBB41_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB31_2:
+; PURECAP-NEXT:  .LBB41_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ne i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -615,18 +765,18 @@ define i8 addrspace(200)* @select_ne_null(i8 addrspace(200)* %a, i8 addrspace(20
 define i8 addrspace(200)* @select_ugt_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ugt_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bltu zero, a0, .LBB32_2
+; HYBRID-NEXT:    bltu zero, a0, .LBB42_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB32_2:
+; HYBRID-NEXT:  .LBB42_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ugt_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bltu zero, a0, .LBB32_2
+; PURECAP-NEXT:    bltu zero, a0, .LBB42_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB32_2:
+; PURECAP-NEXT:  .LBB42_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ugt i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -636,18 +786,18 @@ define i8 addrspace(200)* @select_ugt_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_uge_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_uge_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bgeu a0, zero, .LBB33_2
+; HYBRID-NEXT:    bgeu a0, zero, .LBB43_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB33_2:
+; HYBRID-NEXT:  .LBB43_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_uge_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bgeu a0, zero, .LBB33_2
+; PURECAP-NEXT:    bgeu a0, zero, .LBB43_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB33_2:
+; PURECAP-NEXT:  .LBB43_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp uge i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -657,18 +807,18 @@ define i8 addrspace(200)* @select_uge_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_ult_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ult_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bltu a0, zero, .LBB34_2
+; HYBRID-NEXT:    bltu a0, zero, .LBB44_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB34_2:
+; HYBRID-NEXT:  .LBB44_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ult_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bltu a0, zero, .LBB34_2
+; PURECAP-NEXT:    bltu a0, zero, .LBB44_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB34_2:
+; PURECAP-NEXT:  .LBB44_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ult i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -678,18 +828,18 @@ define i8 addrspace(200)* @select_ult_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_ule_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ule_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bgeu zero, a0, .LBB35_2
+; HYBRID-NEXT:    bgeu zero, a0, .LBB45_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB35_2:
+; HYBRID-NEXT:  .LBB45_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ule_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bgeu zero, a0, .LBB35_2
+; PURECAP-NEXT:    bgeu zero, a0, .LBB45_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB35_2:
+; PURECAP-NEXT:  .LBB45_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ule i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -699,18 +849,18 @@ define i8 addrspace(200)* @select_ule_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_sgt_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_sgt_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bgtz a0, .LBB36_2
+; HYBRID-NEXT:    bgtz a0, .LBB46_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB36_2:
+; HYBRID-NEXT:  .LBB46_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_sgt_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bgtz a0, .LBB36_2
+; PURECAP-NEXT:    bgtz a0, .LBB46_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB36_2:
+; PURECAP-NEXT:  .LBB46_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp sgt i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -720,18 +870,18 @@ define i8 addrspace(200)* @select_sgt_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_sge_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_sge_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bgez a0, .LBB37_2
+; HYBRID-NEXT:    bgez a0, .LBB47_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB37_2:
+; HYBRID-NEXT:  .LBB47_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_sge_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bgez a0, .LBB37_2
+; PURECAP-NEXT:    bgez a0, .LBB47_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB37_2:
+; PURECAP-NEXT:  .LBB47_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp sge i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -741,18 +891,18 @@ define i8 addrspace(200)* @select_sge_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_slt_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_slt_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bltz a0, .LBB38_2
+; HYBRID-NEXT:    bltz a0, .LBB48_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB38_2:
+; HYBRID-NEXT:  .LBB48_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_slt_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bltz a0, .LBB38_2
+; PURECAP-NEXT:    bltz a0, .LBB48_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB38_2:
+; PURECAP-NEXT:  .LBB48_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp slt i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -762,18 +912,18 @@ define i8 addrspace(200)* @select_slt_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_sle_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_sle_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    blez a0, .LBB39_2
+; HYBRID-NEXT:    blez a0, .LBB49_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB39_2:
+; HYBRID-NEXT:  .LBB49_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_sle_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    blez a0, .LBB39_2
+; PURECAP-NEXT:    blez a0, .LBB49_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB39_2:
+; PURECAP-NEXT:  .LBB49_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp sle i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -786,18 +936,18 @@ declare i32 @func2() nounwind
 define i32 @branch_eq(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_eq:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    beq a0, a1, .LBB40_2
+; HYBRID-NEXT:    beq a0, a1, .LBB50_2
 ; HYBRID-NEXT:  # %bb.1: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
-; HYBRID-NEXT:  .LBB40_2: # %if.then
+; HYBRID-NEXT:  .LBB50_2: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
 ;
 ; PURECAP-LABEL: branch_eq:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    beq a0, a1, .LBB40_2
+; PURECAP-NEXT:    beq a0, a1, .LBB50_2
 ; PURECAP-NEXT:  # %bb.1: # %if.end
 ; PURECAP-NEXT:    ctail func2
-; PURECAP-NEXT:  .LBB40_2: # %if.then
+; PURECAP-NEXT:  .LBB50_2: # %if.then
 ; PURECAP-NEXT:    ctail func1
 entry:
   %cmp = icmp eq i8 addrspace(200)* %a, %b
@@ -813,18 +963,18 @@ if.end:
 define i32 @branch_ne(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_ne:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    beq a0, a1, .LBB41_2
+; HYBRID-NEXT:    beq a0, a1, .LBB51_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB41_2: # %if.end
+; HYBRID-NEXT:  .LBB51_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ne:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    beq a0, a1, .LBB41_2
+; PURECAP-NEXT:    beq a0, a1, .LBB51_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB41_2: # %if.end
+; PURECAP-NEXT:  .LBB51_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ne i8 addrspace(200)* %a, %b
@@ -840,18 +990,18 @@ if.end:
 define i32 @branch_ugt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_ugt:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bgeu a1, a0, .LBB42_2
+; HYBRID-NEXT:    bgeu a1, a0, .LBB52_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB42_2: # %if.end
+; HYBRID-NEXT:  .LBB52_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ugt:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bgeu a1, a0, .LBB42_2
+; PURECAP-NEXT:    bgeu a1, a0, .LBB52_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB42_2: # %if.end
+; PURECAP-NEXT:  .LBB52_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ugt i8 addrspace(200)* %a, %b
@@ -867,18 +1017,18 @@ if.end:
 define i32 @branch_uge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_uge:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bltu a0, a1, .LBB43_2
+; HYBRID-NEXT:    bltu a0, a1, .LBB53_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB43_2: # %if.end
+; HYBRID-NEXT:  .LBB53_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_uge:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bltu a0, a1, .LBB43_2
+; PURECAP-NEXT:    bltu a0, a1, .LBB53_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB43_2: # %if.end
+; PURECAP-NEXT:  .LBB53_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp uge i8 addrspace(200)* %a, %b
@@ -894,18 +1044,18 @@ if.end:
 define i32 @branch_ult(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_ult:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bgeu a0, a1, .LBB44_2
+; HYBRID-NEXT:    bgeu a0, a1, .LBB54_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB44_2: # %if.end
+; HYBRID-NEXT:  .LBB54_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ult:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bgeu a0, a1, .LBB44_2
+; PURECAP-NEXT:    bgeu a0, a1, .LBB54_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB44_2: # %if.end
+; PURECAP-NEXT:  .LBB54_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ult i8 addrspace(200)* %a, %b
@@ -921,18 +1071,18 @@ if.end:
 define i32 @branch_ule(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_ule:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bltu a1, a0, .LBB45_2
+; HYBRID-NEXT:    bltu a1, a0, .LBB55_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB45_2: # %if.end
+; HYBRID-NEXT:  .LBB55_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ule:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bltu a1, a0, .LBB45_2
+; PURECAP-NEXT:    bltu a1, a0, .LBB55_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB45_2: # %if.end
+; PURECAP-NEXT:  .LBB55_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ule i8 addrspace(200)* %a, %b
@@ -948,18 +1098,18 @@ if.end:
 define i32 @branch_sgt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_sgt:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bge a1, a0, .LBB46_2
+; HYBRID-NEXT:    bge a1, a0, .LBB56_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB46_2: # %if.end
+; HYBRID-NEXT:  .LBB56_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_sgt:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bge a1, a0, .LBB46_2
+; PURECAP-NEXT:    bge a1, a0, .LBB56_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB46_2: # %if.end
+; PURECAP-NEXT:  .LBB56_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp sgt i8 addrspace(200)* %a, %b
@@ -975,18 +1125,18 @@ if.end:
 define i32 @branch_sge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_sge:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    blt a0, a1, .LBB47_2
+; HYBRID-NEXT:    blt a0, a1, .LBB57_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB47_2: # %if.end
+; HYBRID-NEXT:  .LBB57_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_sge:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    blt a0, a1, .LBB47_2
+; PURECAP-NEXT:    blt a0, a1, .LBB57_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB47_2: # %if.end
+; PURECAP-NEXT:  .LBB57_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp sge i8 addrspace(200)* %a, %b
@@ -1002,18 +1152,18 @@ if.end:
 define i32 @branch_slt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_slt:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bge a0, a1, .LBB48_2
+; HYBRID-NEXT:    bge a0, a1, .LBB58_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB48_2: # %if.end
+; HYBRID-NEXT:  .LBB58_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_slt:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bge a0, a1, .LBB48_2
+; PURECAP-NEXT:    bge a0, a1, .LBB58_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB48_2: # %if.end
+; PURECAP-NEXT:  .LBB58_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp slt i8 addrspace(200)* %a, %b
@@ -1029,18 +1179,18 @@ if.end:
 define i32 @branch_sle(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_sle:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    blt a1, a0, .LBB49_2
+; HYBRID-NEXT:    blt a1, a0, .LBB59_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB49_2: # %if.end
+; HYBRID-NEXT:  .LBB59_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_sle:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    blt a1, a0, .LBB49_2
+; PURECAP-NEXT:    blt a1, a0, .LBB59_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB49_2: # %if.end
+; PURECAP-NEXT:  .LBB59_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp sle i8 addrspace(200)* %a, %b
@@ -1056,18 +1206,18 @@ if.end:
 define i32 @branch_eq_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_eq_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    beqz a0, .LBB50_2
+; HYBRID-NEXT:    beqz a0, .LBB60_2
 ; HYBRID-NEXT:  # %bb.1: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
-; HYBRID-NEXT:  .LBB50_2: # %if.then
+; HYBRID-NEXT:  .LBB60_2: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
 ;
 ; PURECAP-LABEL: branch_eq_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    beqz a0, .LBB50_2
+; PURECAP-NEXT:    beqz a0, .LBB60_2
 ; PURECAP-NEXT:  # %bb.1: # %if.end
 ; PURECAP-NEXT:    ctail func2
-; PURECAP-NEXT:  .LBB50_2: # %if.then
+; PURECAP-NEXT:  .LBB60_2: # %if.then
 ; PURECAP-NEXT:    ctail func1
 entry:
   %cmp = icmp eq i8 addrspace(200)* %a, null
@@ -1083,18 +1233,18 @@ if.end:
 define i32 @branch_ne_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_ne_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    beqz a0, .LBB51_2
+; HYBRID-NEXT:    beqz a0, .LBB61_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB51_2: # %if.end
+; HYBRID-NEXT:  .LBB61_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ne_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    beqz a0, .LBB51_2
+; PURECAP-NEXT:    beqz a0, .LBB61_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB51_2: # %if.end
+; PURECAP-NEXT:  .LBB61_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ne i8 addrspace(200)* %a, null
@@ -1110,18 +1260,18 @@ if.end:
 define i32 @branch_ugt_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_ugt_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bgeu zero, a0, .LBB52_2
+; HYBRID-NEXT:    bgeu zero, a0, .LBB62_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB52_2: # %if.end
+; HYBRID-NEXT:  .LBB62_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ugt_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bgeu zero, a0, .LBB52_2
+; PURECAP-NEXT:    bgeu zero, a0, .LBB62_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB52_2: # %if.end
+; PURECAP-NEXT:  .LBB62_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ugt i8 addrspace(200)* %a, null
@@ -1137,18 +1287,18 @@ if.end:
 define i32 @branch_uge_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_uge_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bltu a0, zero, .LBB53_2
+; HYBRID-NEXT:    bltu a0, zero, .LBB63_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB53_2: # %if.end
+; HYBRID-NEXT:  .LBB63_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_uge_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bltu a0, zero, .LBB53_2
+; PURECAP-NEXT:    bltu a0, zero, .LBB63_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB53_2: # %if.end
+; PURECAP-NEXT:  .LBB63_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp uge i8 addrspace(200)* %a, null
@@ -1164,18 +1314,18 @@ if.end:
 define i32 @branch_ult_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_ult_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bgeu a0, zero, .LBB54_2
+; HYBRID-NEXT:    bgeu a0, zero, .LBB64_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB54_2: # %if.end
+; HYBRID-NEXT:  .LBB64_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ult_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bgeu a0, zero, .LBB54_2
+; PURECAP-NEXT:    bgeu a0, zero, .LBB64_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB54_2: # %if.end
+; PURECAP-NEXT:  .LBB64_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ult i8 addrspace(200)* %a, null
@@ -1191,18 +1341,18 @@ if.end:
 define i32 @branch_ule_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_ule_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bltu zero, a0, .LBB55_2
+; HYBRID-NEXT:    bltu zero, a0, .LBB65_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB55_2: # %if.end
+; HYBRID-NEXT:  .LBB65_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ule_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bltu zero, a0, .LBB55_2
+; PURECAP-NEXT:    bltu zero, a0, .LBB65_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB55_2: # %if.end
+; PURECAP-NEXT:  .LBB65_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ule i8 addrspace(200)* %a, null
@@ -1218,18 +1368,18 @@ if.end:
 define i32 @branch_sgt_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_sgt_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    blez a0, .LBB56_2
+; HYBRID-NEXT:    blez a0, .LBB66_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB56_2: # %if.end
+; HYBRID-NEXT:  .LBB66_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_sgt_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    blez a0, .LBB56_2
+; PURECAP-NEXT:    blez a0, .LBB66_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB56_2: # %if.end
+; PURECAP-NEXT:  .LBB66_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp sgt i8 addrspace(200)* %a, null
@@ -1245,18 +1395,18 @@ if.end:
 define i32 @branch_sge_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_sge_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bltz a0, .LBB57_2
+; HYBRID-NEXT:    bltz a0, .LBB67_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB57_2: # %if.end
+; HYBRID-NEXT:  .LBB67_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_sge_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bltz a0, .LBB57_2
+; PURECAP-NEXT:    bltz a0, .LBB67_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB57_2: # %if.end
+; PURECAP-NEXT:  .LBB67_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp sge i8 addrspace(200)* %a, null
@@ -1272,18 +1422,18 @@ if.end:
 define i32 @branch_slt_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_slt_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bgez a0, .LBB58_2
+; HYBRID-NEXT:    bgez a0, .LBB68_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB58_2: # %if.end
+; HYBRID-NEXT:  .LBB68_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_slt_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bgez a0, .LBB58_2
+; PURECAP-NEXT:    bgez a0, .LBB68_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB58_2: # %if.end
+; PURECAP-NEXT:  .LBB68_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp slt i8 addrspace(200)* %a, null
@@ -1299,18 +1449,18 @@ if.end:
 define i32 @branch_sle_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_sle_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bgtz a0, .LBB59_2
+; HYBRID-NEXT:    bgtz a0, .LBB69_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB59_2: # %if.end
+; HYBRID-NEXT:  .LBB69_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_sle_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bgtz a0, .LBB59_2
+; PURECAP-NEXT:    bgtz a0, .LBB69_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB59_2: # %if.end
+; PURECAP-NEXT:  .LBB69_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp sle i8 addrspace(200)* %a, null

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV64/cheri-pointer-comparison.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV64/cheri-pointer-comparison.ll
@@ -202,6 +202,156 @@ define i32 @sle(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
   ret i32 %conv
 }
 
+define i32 @eq_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: eq_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 1
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: eq_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 1
+; PURECAP-NEXT:    ret
+  %cmp = icmp eq i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ne_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: ne_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 0
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: ne_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 0
+; PURECAP-NEXT:    ret
+  %cmp = icmp ne i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ugt_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: ugt_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 0
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: ugt_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 0
+; PURECAP-NEXT:    ret
+  %cmp = icmp ugt i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @uge_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: uge_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 1
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: uge_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 1
+; PURECAP-NEXT:    ret
+  %cmp = icmp uge i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ult_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: ult_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 0
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: ult_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 0
+; PURECAP-NEXT:    ret
+  %cmp = icmp ult i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @ule_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: ule_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 1
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: ule_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 1
+; PURECAP-NEXT:    ret
+  %cmp = icmp ule i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @sgt_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: sgt_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 0
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: sgt_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 0
+; PURECAP-NEXT:    ret
+  %cmp = icmp sgt i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @sge_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: sge_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 1
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: sge_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 1
+; PURECAP-NEXT:    ret
+  %cmp = icmp sge i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @slt_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: slt_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 0
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: slt_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 0
+; PURECAP-NEXT:    ret
+  %cmp = icmp slt i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @sle_same(i8 addrspace(200)* %a) nounwind {
+; HYBRID-LABEL: sle_same:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    li a0, 1
+; HYBRID-NEXT:    ret
+;
+; PURECAP-LABEL: sle_same:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    li a0, 1
+; PURECAP-NEXT:    ret
+  %cmp = icmp sle i8 addrspace(200)* %a, %a
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
 define i32 @eq_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: eq_null:
 ; HYBRID:       # %bb.0:
@@ -363,18 +513,18 @@ define i32 @sle_null(i8 addrspace(200)* %a) nounwind {
 define i8 addrspace(200)* @select_eq(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_eq:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    beq a0, a1, .LBB20_2
+; HYBRID-NEXT:    beq a0, a1, .LBB30_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB20_2:
+; HYBRID-NEXT:  .LBB30_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_eq:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    beq a0, a1, .LBB20_2
+; PURECAP-NEXT:    beq a0, a1, .LBB30_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB20_2:
+; PURECAP-NEXT:  .LBB30_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp eq i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -384,18 +534,18 @@ define i8 addrspace(200)* @select_eq(i8 addrspace(200)* %a, i8 addrspace(200)* %
 define i8 addrspace(200)* @select_ne(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ne:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bne a0, a1, .LBB21_2
+; HYBRID-NEXT:    bne a0, a1, .LBB31_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB21_2:
+; HYBRID-NEXT:  .LBB31_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ne:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bne a0, a1, .LBB21_2
+; PURECAP-NEXT:    bne a0, a1, .LBB31_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB21_2:
+; PURECAP-NEXT:  .LBB31_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ne i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -405,18 +555,18 @@ define i8 addrspace(200)* @select_ne(i8 addrspace(200)* %a, i8 addrspace(200)* %
 define i8 addrspace(200)* @select_ugt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ugt:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bltu a1, a0, .LBB22_2
+; HYBRID-NEXT:    bltu a1, a0, .LBB32_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB22_2:
+; HYBRID-NEXT:  .LBB32_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ugt:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bltu a1, a0, .LBB22_2
+; PURECAP-NEXT:    bltu a1, a0, .LBB32_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB22_2:
+; PURECAP-NEXT:  .LBB32_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ugt i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -426,18 +576,18 @@ define i8 addrspace(200)* @select_ugt(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_uge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_uge:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bgeu a0, a1, .LBB23_2
+; HYBRID-NEXT:    bgeu a0, a1, .LBB33_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB23_2:
+; HYBRID-NEXT:  .LBB33_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_uge:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bgeu a0, a1, .LBB23_2
+; PURECAP-NEXT:    bgeu a0, a1, .LBB33_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB23_2:
+; PURECAP-NEXT:  .LBB33_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp uge i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -447,18 +597,18 @@ define i8 addrspace(200)* @select_uge(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_ult(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ult:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bltu a0, a1, .LBB24_2
+; HYBRID-NEXT:    bltu a0, a1, .LBB34_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB24_2:
+; HYBRID-NEXT:  .LBB34_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ult:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bltu a0, a1, .LBB24_2
+; PURECAP-NEXT:    bltu a0, a1, .LBB34_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB24_2:
+; PURECAP-NEXT:  .LBB34_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ult i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -468,18 +618,18 @@ define i8 addrspace(200)* @select_ult(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_ule(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ule:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bgeu a1, a0, .LBB25_2
+; HYBRID-NEXT:    bgeu a1, a0, .LBB35_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB25_2:
+; HYBRID-NEXT:  .LBB35_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ule:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bgeu a1, a0, .LBB25_2
+; PURECAP-NEXT:    bgeu a1, a0, .LBB35_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB25_2:
+; PURECAP-NEXT:  .LBB35_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ule i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -489,18 +639,18 @@ define i8 addrspace(200)* @select_ule(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_sgt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_sgt:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    blt a1, a0, .LBB26_2
+; HYBRID-NEXT:    blt a1, a0, .LBB36_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB26_2:
+; HYBRID-NEXT:  .LBB36_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_sgt:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    blt a1, a0, .LBB26_2
+; PURECAP-NEXT:    blt a1, a0, .LBB36_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB26_2:
+; PURECAP-NEXT:  .LBB36_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp sgt i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -510,18 +660,18 @@ define i8 addrspace(200)* @select_sgt(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_sge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_sge:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bge a0, a1, .LBB27_2
+; HYBRID-NEXT:    bge a0, a1, .LBB37_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB27_2:
+; HYBRID-NEXT:  .LBB37_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_sge:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bge a0, a1, .LBB27_2
+; PURECAP-NEXT:    bge a0, a1, .LBB37_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB27_2:
+; PURECAP-NEXT:  .LBB37_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp sge i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -531,18 +681,18 @@ define i8 addrspace(200)* @select_sge(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_slt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_slt:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    blt a0, a1, .LBB28_2
+; HYBRID-NEXT:    blt a0, a1, .LBB38_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB28_2:
+; HYBRID-NEXT:  .LBB38_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_slt:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    blt a0, a1, .LBB28_2
+; PURECAP-NEXT:    blt a0, a1, .LBB38_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB28_2:
+; PURECAP-NEXT:  .LBB38_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp slt i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -552,18 +702,18 @@ define i8 addrspace(200)* @select_slt(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_sle(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_sle:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bge a1, a0, .LBB29_2
+; HYBRID-NEXT:    bge a1, a0, .LBB39_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB29_2:
+; HYBRID-NEXT:  .LBB39_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_sle:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bge a1, a0, .LBB29_2
+; PURECAP-NEXT:    bge a1, a0, .LBB39_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB29_2:
+; PURECAP-NEXT:  .LBB39_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp sle i8 addrspace(200)* %a, %b
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -573,18 +723,18 @@ define i8 addrspace(200)* @select_sle(i8 addrspace(200)* %a, i8 addrspace(200)* 
 define i8 addrspace(200)* @select_eq_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_eq_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    beqz a0, .LBB30_2
+; HYBRID-NEXT:    beqz a0, .LBB40_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB30_2:
+; HYBRID-NEXT:  .LBB40_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_eq_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    beqz a0, .LBB30_2
+; PURECAP-NEXT:    beqz a0, .LBB40_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB30_2:
+; PURECAP-NEXT:  .LBB40_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp eq i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -594,18 +744,18 @@ define i8 addrspace(200)* @select_eq_null(i8 addrspace(200)* %a, i8 addrspace(20
 define i8 addrspace(200)* @select_ne_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ne_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bnez a0, .LBB31_2
+; HYBRID-NEXT:    bnez a0, .LBB41_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB31_2:
+; HYBRID-NEXT:  .LBB41_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ne_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bnez a0, .LBB31_2
+; PURECAP-NEXT:    bnez a0, .LBB41_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB31_2:
+; PURECAP-NEXT:  .LBB41_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ne i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -615,18 +765,18 @@ define i8 addrspace(200)* @select_ne_null(i8 addrspace(200)* %a, i8 addrspace(20
 define i8 addrspace(200)* @select_ugt_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ugt_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bltu zero, a0, .LBB32_2
+; HYBRID-NEXT:    bltu zero, a0, .LBB42_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB32_2:
+; HYBRID-NEXT:  .LBB42_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ugt_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bltu zero, a0, .LBB32_2
+; PURECAP-NEXT:    bltu zero, a0, .LBB42_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB32_2:
+; PURECAP-NEXT:  .LBB42_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ugt i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -636,18 +786,18 @@ define i8 addrspace(200)* @select_ugt_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_uge_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_uge_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bgeu a0, zero, .LBB33_2
+; HYBRID-NEXT:    bgeu a0, zero, .LBB43_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB33_2:
+; HYBRID-NEXT:  .LBB43_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_uge_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bgeu a0, zero, .LBB33_2
+; PURECAP-NEXT:    bgeu a0, zero, .LBB43_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB33_2:
+; PURECAP-NEXT:  .LBB43_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp uge i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -657,18 +807,18 @@ define i8 addrspace(200)* @select_uge_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_ult_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ult_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bltu a0, zero, .LBB34_2
+; HYBRID-NEXT:    bltu a0, zero, .LBB44_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB34_2:
+; HYBRID-NEXT:  .LBB44_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ult_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bltu a0, zero, .LBB34_2
+; PURECAP-NEXT:    bltu a0, zero, .LBB44_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB34_2:
+; PURECAP-NEXT:  .LBB44_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ult i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -678,18 +828,18 @@ define i8 addrspace(200)* @select_ult_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_ule_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_ule_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bgeu zero, a0, .LBB35_2
+; HYBRID-NEXT:    bgeu zero, a0, .LBB45_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB35_2:
+; HYBRID-NEXT:  .LBB45_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_ule_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bgeu zero, a0, .LBB35_2
+; PURECAP-NEXT:    bgeu zero, a0, .LBB45_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB35_2:
+; PURECAP-NEXT:  .LBB45_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp ule i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -699,18 +849,18 @@ define i8 addrspace(200)* @select_ule_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_sgt_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_sgt_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bgtz a0, .LBB36_2
+; HYBRID-NEXT:    bgtz a0, .LBB46_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB36_2:
+; HYBRID-NEXT:  .LBB46_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_sgt_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bgtz a0, .LBB36_2
+; PURECAP-NEXT:    bgtz a0, .LBB46_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB36_2:
+; PURECAP-NEXT:  .LBB46_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp sgt i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -720,18 +870,18 @@ define i8 addrspace(200)* @select_sgt_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_sge_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_sge_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bgez a0, .LBB37_2
+; HYBRID-NEXT:    bgez a0, .LBB47_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB37_2:
+; HYBRID-NEXT:  .LBB47_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_sge_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bgez a0, .LBB37_2
+; PURECAP-NEXT:    bgez a0, .LBB47_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB37_2:
+; PURECAP-NEXT:  .LBB47_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp sge i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -741,18 +891,18 @@ define i8 addrspace(200)* @select_sge_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_slt_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_slt_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bltz a0, .LBB38_2
+; HYBRID-NEXT:    bltz a0, .LBB48_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB38_2:
+; HYBRID-NEXT:  .LBB48_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_slt_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bltz a0, .LBB38_2
+; PURECAP-NEXT:    bltz a0, .LBB48_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB38_2:
+; PURECAP-NEXT:  .LBB48_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp slt i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -762,18 +912,18 @@ define i8 addrspace(200)* @select_slt_null(i8 addrspace(200)* %a, i8 addrspace(2
 define i8 addrspace(200)* @select_sle_null(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: select_sle_null:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    blez a0, .LBB39_2
+; HYBRID-NEXT:    blez a0, .LBB49_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmove ca0, ca1
-; HYBRID-NEXT:  .LBB39_2:
+; HYBRID-NEXT:  .LBB49_2:
 ; HYBRID-NEXT:    ret
 ;
 ; PURECAP-LABEL: select_sle_null:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    blez a0, .LBB39_2
+; PURECAP-NEXT:    blez a0, .LBB49_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmove ca0, ca1
-; PURECAP-NEXT:  .LBB39_2:
+; PURECAP-NEXT:  .LBB49_2:
 ; PURECAP-NEXT:    ret
   %cmp = icmp sle i8 addrspace(200)* %a, null
   %cond = select i1 %cmp, i8 addrspace(200)* %a, i8 addrspace(200)* %b
@@ -786,18 +936,18 @@ declare i32 @func2() nounwind
 define i32 @branch_eq(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_eq:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    beq a0, a1, .LBB40_2
+; HYBRID-NEXT:    beq a0, a1, .LBB50_2
 ; HYBRID-NEXT:  # %bb.1: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
-; HYBRID-NEXT:  .LBB40_2: # %if.then
+; HYBRID-NEXT:  .LBB50_2: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
 ;
 ; PURECAP-LABEL: branch_eq:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    beq a0, a1, .LBB40_2
+; PURECAP-NEXT:    beq a0, a1, .LBB50_2
 ; PURECAP-NEXT:  # %bb.1: # %if.end
 ; PURECAP-NEXT:    ctail func2
-; PURECAP-NEXT:  .LBB40_2: # %if.then
+; PURECAP-NEXT:  .LBB50_2: # %if.then
 ; PURECAP-NEXT:    ctail func1
 entry:
   %cmp = icmp eq i8 addrspace(200)* %a, %b
@@ -813,18 +963,18 @@ if.end:
 define i32 @branch_ne(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_ne:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    beq a0, a1, .LBB41_2
+; HYBRID-NEXT:    beq a0, a1, .LBB51_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB41_2: # %if.end
+; HYBRID-NEXT:  .LBB51_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ne:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    beq a0, a1, .LBB41_2
+; PURECAP-NEXT:    beq a0, a1, .LBB51_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB41_2: # %if.end
+; PURECAP-NEXT:  .LBB51_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ne i8 addrspace(200)* %a, %b
@@ -840,18 +990,18 @@ if.end:
 define i32 @branch_ugt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_ugt:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bgeu a1, a0, .LBB42_2
+; HYBRID-NEXT:    bgeu a1, a0, .LBB52_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB42_2: # %if.end
+; HYBRID-NEXT:  .LBB52_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ugt:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bgeu a1, a0, .LBB42_2
+; PURECAP-NEXT:    bgeu a1, a0, .LBB52_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB42_2: # %if.end
+; PURECAP-NEXT:  .LBB52_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ugt i8 addrspace(200)* %a, %b
@@ -867,18 +1017,18 @@ if.end:
 define i32 @branch_uge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_uge:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bltu a0, a1, .LBB43_2
+; HYBRID-NEXT:    bltu a0, a1, .LBB53_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB43_2: # %if.end
+; HYBRID-NEXT:  .LBB53_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_uge:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bltu a0, a1, .LBB43_2
+; PURECAP-NEXT:    bltu a0, a1, .LBB53_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB43_2: # %if.end
+; PURECAP-NEXT:  .LBB53_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp uge i8 addrspace(200)* %a, %b
@@ -894,18 +1044,18 @@ if.end:
 define i32 @branch_ult(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_ult:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bgeu a0, a1, .LBB44_2
+; HYBRID-NEXT:    bgeu a0, a1, .LBB54_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB44_2: # %if.end
+; HYBRID-NEXT:  .LBB54_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ult:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bgeu a0, a1, .LBB44_2
+; PURECAP-NEXT:    bgeu a0, a1, .LBB54_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB44_2: # %if.end
+; PURECAP-NEXT:  .LBB54_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ult i8 addrspace(200)* %a, %b
@@ -921,18 +1071,18 @@ if.end:
 define i32 @branch_ule(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_ule:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bltu a1, a0, .LBB45_2
+; HYBRID-NEXT:    bltu a1, a0, .LBB55_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB45_2: # %if.end
+; HYBRID-NEXT:  .LBB55_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ule:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bltu a1, a0, .LBB45_2
+; PURECAP-NEXT:    bltu a1, a0, .LBB55_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB45_2: # %if.end
+; PURECAP-NEXT:  .LBB55_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ule i8 addrspace(200)* %a, %b
@@ -948,18 +1098,18 @@ if.end:
 define i32 @branch_sgt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_sgt:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bge a1, a0, .LBB46_2
+; HYBRID-NEXT:    bge a1, a0, .LBB56_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB46_2: # %if.end
+; HYBRID-NEXT:  .LBB56_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_sgt:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bge a1, a0, .LBB46_2
+; PURECAP-NEXT:    bge a1, a0, .LBB56_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB46_2: # %if.end
+; PURECAP-NEXT:  .LBB56_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp sgt i8 addrspace(200)* %a, %b
@@ -975,18 +1125,18 @@ if.end:
 define i32 @branch_sge(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_sge:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    blt a0, a1, .LBB47_2
+; HYBRID-NEXT:    blt a0, a1, .LBB57_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB47_2: # %if.end
+; HYBRID-NEXT:  .LBB57_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_sge:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    blt a0, a1, .LBB47_2
+; PURECAP-NEXT:    blt a0, a1, .LBB57_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB47_2: # %if.end
+; PURECAP-NEXT:  .LBB57_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp sge i8 addrspace(200)* %a, %b
@@ -1002,18 +1152,18 @@ if.end:
 define i32 @branch_slt(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_slt:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bge a0, a1, .LBB48_2
+; HYBRID-NEXT:    bge a0, a1, .LBB58_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB48_2: # %if.end
+; HYBRID-NEXT:  .LBB58_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_slt:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bge a0, a1, .LBB48_2
+; PURECAP-NEXT:    bge a0, a1, .LBB58_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB48_2: # %if.end
+; PURECAP-NEXT:  .LBB58_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp slt i8 addrspace(200)* %a, %b
@@ -1029,18 +1179,18 @@ if.end:
 define i32 @branch_sle(i8 addrspace(200)* %a, i8 addrspace(200)* %b) nounwind {
 ; HYBRID-LABEL: branch_sle:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    blt a1, a0, .LBB49_2
+; HYBRID-NEXT:    blt a1, a0, .LBB59_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB49_2: # %if.end
+; HYBRID-NEXT:  .LBB59_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_sle:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    blt a1, a0, .LBB49_2
+; PURECAP-NEXT:    blt a1, a0, .LBB59_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB49_2: # %if.end
+; PURECAP-NEXT:  .LBB59_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp sle i8 addrspace(200)* %a, %b
@@ -1056,18 +1206,18 @@ if.end:
 define i32 @branch_eq_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_eq_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    beqz a0, .LBB50_2
+; HYBRID-NEXT:    beqz a0, .LBB60_2
 ; HYBRID-NEXT:  # %bb.1: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
-; HYBRID-NEXT:  .LBB50_2: # %if.then
+; HYBRID-NEXT:  .LBB60_2: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
 ;
 ; PURECAP-LABEL: branch_eq_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    beqz a0, .LBB50_2
+; PURECAP-NEXT:    beqz a0, .LBB60_2
 ; PURECAP-NEXT:  # %bb.1: # %if.end
 ; PURECAP-NEXT:    ctail func2
-; PURECAP-NEXT:  .LBB50_2: # %if.then
+; PURECAP-NEXT:  .LBB60_2: # %if.then
 ; PURECAP-NEXT:    ctail func1
 entry:
   %cmp = icmp eq i8 addrspace(200)* %a, null
@@ -1083,18 +1233,18 @@ if.end:
 define i32 @branch_ne_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_ne_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    beqz a0, .LBB51_2
+; HYBRID-NEXT:    beqz a0, .LBB61_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB51_2: # %if.end
+; HYBRID-NEXT:  .LBB61_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ne_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    beqz a0, .LBB51_2
+; PURECAP-NEXT:    beqz a0, .LBB61_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB51_2: # %if.end
+; PURECAP-NEXT:  .LBB61_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ne i8 addrspace(200)* %a, null
@@ -1110,18 +1260,18 @@ if.end:
 define i32 @branch_ugt_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_ugt_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bgeu zero, a0, .LBB52_2
+; HYBRID-NEXT:    bgeu zero, a0, .LBB62_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB52_2: # %if.end
+; HYBRID-NEXT:  .LBB62_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ugt_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bgeu zero, a0, .LBB52_2
+; PURECAP-NEXT:    bgeu zero, a0, .LBB62_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB52_2: # %if.end
+; PURECAP-NEXT:  .LBB62_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ugt i8 addrspace(200)* %a, null
@@ -1137,18 +1287,18 @@ if.end:
 define i32 @branch_uge_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_uge_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bltu a0, zero, .LBB53_2
+; HYBRID-NEXT:    bltu a0, zero, .LBB63_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB53_2: # %if.end
+; HYBRID-NEXT:  .LBB63_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_uge_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bltu a0, zero, .LBB53_2
+; PURECAP-NEXT:    bltu a0, zero, .LBB63_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB53_2: # %if.end
+; PURECAP-NEXT:  .LBB63_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp uge i8 addrspace(200)* %a, null
@@ -1164,18 +1314,18 @@ if.end:
 define i32 @branch_ult_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_ult_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bgeu a0, zero, .LBB54_2
+; HYBRID-NEXT:    bgeu a0, zero, .LBB64_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB54_2: # %if.end
+; HYBRID-NEXT:  .LBB64_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ult_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bgeu a0, zero, .LBB54_2
+; PURECAP-NEXT:    bgeu a0, zero, .LBB64_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB54_2: # %if.end
+; PURECAP-NEXT:  .LBB64_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ult i8 addrspace(200)* %a, null
@@ -1191,18 +1341,18 @@ if.end:
 define i32 @branch_ule_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_ule_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bltu zero, a0, .LBB55_2
+; HYBRID-NEXT:    bltu zero, a0, .LBB65_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB55_2: # %if.end
+; HYBRID-NEXT:  .LBB65_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_ule_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bltu zero, a0, .LBB55_2
+; PURECAP-NEXT:    bltu zero, a0, .LBB65_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB55_2: # %if.end
+; PURECAP-NEXT:  .LBB65_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp ule i8 addrspace(200)* %a, null
@@ -1218,18 +1368,18 @@ if.end:
 define i32 @branch_sgt_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_sgt_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    blez a0, .LBB56_2
+; HYBRID-NEXT:    blez a0, .LBB66_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB56_2: # %if.end
+; HYBRID-NEXT:  .LBB66_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_sgt_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    blez a0, .LBB56_2
+; PURECAP-NEXT:    blez a0, .LBB66_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB56_2: # %if.end
+; PURECAP-NEXT:  .LBB66_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp sgt i8 addrspace(200)* %a, null
@@ -1245,18 +1395,18 @@ if.end:
 define i32 @branch_sge_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_sge_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bltz a0, .LBB57_2
+; HYBRID-NEXT:    bltz a0, .LBB67_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB57_2: # %if.end
+; HYBRID-NEXT:  .LBB67_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_sge_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bltz a0, .LBB57_2
+; PURECAP-NEXT:    bltz a0, .LBB67_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB57_2: # %if.end
+; PURECAP-NEXT:  .LBB67_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp sge i8 addrspace(200)* %a, null
@@ -1272,18 +1422,18 @@ if.end:
 define i32 @branch_slt_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_slt_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bgez a0, .LBB58_2
+; HYBRID-NEXT:    bgez a0, .LBB68_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB58_2: # %if.end
+; HYBRID-NEXT:  .LBB68_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_slt_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bgez a0, .LBB58_2
+; PURECAP-NEXT:    bgez a0, .LBB68_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB58_2: # %if.end
+; PURECAP-NEXT:  .LBB68_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp slt i8 addrspace(200)* %a, null
@@ -1299,18 +1449,18 @@ if.end:
 define i32 @branch_sle_null(i8 addrspace(200)* %a) nounwind {
 ; HYBRID-LABEL: branch_sle_null:
 ; HYBRID:       # %bb.0: # %entry
-; HYBRID-NEXT:    bgtz a0, .LBB59_2
+; HYBRID-NEXT:    bgtz a0, .LBB69_2
 ; HYBRID-NEXT:  # %bb.1: # %if.then
 ; HYBRID-NEXT:    tail func1@plt
-; HYBRID-NEXT:  .LBB59_2: # %if.end
+; HYBRID-NEXT:  .LBB69_2: # %if.end
 ; HYBRID-NEXT:    tail func2@plt
 ;
 ; PURECAP-LABEL: branch_sle_null:
 ; PURECAP:       # %bb.0: # %entry
-; PURECAP-NEXT:    bgtz a0, .LBB59_2
+; PURECAP-NEXT:    bgtz a0, .LBB69_2
 ; PURECAP-NEXT:  # %bb.1: # %if.then
 ; PURECAP-NEXT:    ctail func1
-; PURECAP-NEXT:  .LBB59_2: # %if.end
+; PURECAP-NEXT:  .LBB69_2: # %if.end
 ; PURECAP-NEXT:    ctail func2
 entry:
   %cmp = icmp sle i8 addrspace(200)* %a, null


### PR DESCRIPTION
Failing to do any folding for a SETCC with fat pointer operands in FoldSetCC resulted in it being combined as if it had floating point operands, which in the case of setcc X, X, setugt, produced setcc X, X, setuo. This couldn't be selected by the target.

Since at this stage, we are operating on the basis that fat pointer compares will be lowered to a comparison of the underlying address, we can fold these compares as if they are integers, at the same time avoiding the above issue.