### PR TITLE
[ELF][Cheri] Support (/path/to/)libfoo.a:bar.o c18n policy syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def jobProperties = [rateLimitBuilds(throttle: [count: 1, durationName: 'hour', 
 ]
 if (env.JOB_NAME.startsWith('CLANG-LLVM-linux/') || env.JOB_NAME.startsWith('CLANG-LLVM-freebsd/')) {
     // Skip pull requests and non-default branches:
-    def archiveBranches = ['master', 'dev', 'upstream-llvm-merge']
+    def archiveBranches = ['master', 'dev', 'upstream-llvm-merge', 'c18n_policy']
     if (!env.CHANGE_ID && (archiveBranches.contains(env.BRANCH_NAME))) {
         archiveArtifacts = true
         cheribuildArgs.add("--use-all-cores")

--- a/lld/ELF/ARMErrataFix.cpp
+++ b/lld/ELF/ARMErrataFix.cpp
@@ -212,7 +212,9 @@ static bool branchDestInFirstRegion(const InputSection *isec, uint64_t off,
   // find the destination address as the branch could be indirected via a thunk
   // or the PLT.
   if (r) {
-    uint64_t dst = (r->expr == R_PLT_PC) ? r->sym->getPltVA() : r->sym->getVA();
+    uint64_t dst = (r->expr == R_PLT_PC)
+                       ? r->sym->getPltVA(isec->getCompartment())
+                       : r->sym->getVA();
     // Account for Thumb PC bias, usually cancelled to 0 by addend of -4.
     destAddr = dst + r->addend + 4;
   } else {
@@ -440,8 +442,9 @@ static void implementPatch(ScanResult sr, InputSection *isec,
       // The final target of the branch may be ARM or Thumb, if the target
       // is ARM then we write the patch in ARM state to avoid a state change
       // Thunk from the patch to the target.
-      uint64_t dstSymAddr = (sr.rel->expr == R_PLT_PC) ? sr.rel->sym->getPltVA()
-                                                       : sr.rel->sym->getVA();
+      uint64_t dstSymAddr = (sr.rel->expr == R_PLT_PC)
+                                ? sr.rel->sym->getPltVA(isec->getCompartment())
+                                : sr.rel->sym->getVA();
       destIsARM = (dstSymAddr & 1) == 0;
     }
     psec = make<Patch657417Section>(isec, sr.off, sr.instr, destIsARM);

--- a/lld/ELF/Arch/AArch64.cpp
+++ b/lld/ELF/Arch/AArch64.cpp
@@ -35,13 +35,14 @@ public:
                      const uint8_t *loc) const override;
   RelType getDynRel(RelType type) const override;
   int64_t getImplicitAddend(const uint8_t *buf, RelType type) const override;
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
   void writeIgotPlt(uint8_t *buf, const Symbol &s) const override;
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
   bool needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                  uint64_t branchAddr, const Symbol &s,
+                  const Compartment &c, uint64_t branchAddr, const Symbol &s,
                   int64_t a) const override;
   uint32_t getThunkSectionSpacing() const override;
   bool inBranchRange(RelType type, uint64_t src, uint64_t dst) const override;
@@ -229,8 +230,8 @@ int64_t AArch64::getImplicitAddend(const uint8_t *buf, RelType type) const {
   }
 }
 
-void AArch64::writeGotPlt(uint8_t *buf, const Symbol &) const {
-  write64(buf, in.plt->getVA());
+void AArch64::writeGotPlt(Compartment &c, uint8_t *buf, const Symbol &) const {
+  write64(buf, c.plt->getVA());
 }
 
 void AArch64::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
@@ -238,7 +239,7 @@ void AArch64::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
     write64(buf, s.getVA());
 }
 
-void AArch64::writePltHeader(uint8_t *buf) const {
+void AArch64::writePltHeader(Compartment &c, uint8_t *buf) const {
   const uint8_t pltData[] = {
       0xf0, 0x7b, 0xbf, 0xa9, // stp    x16, x30, [sp,#-16]!
       0x10, 0x00, 0x00, 0x90, // adrp   x16, Page(&(.got.plt[2]))
@@ -251,15 +252,15 @@ void AArch64::writePltHeader(uint8_t *buf) const {
   };
   memcpy(buf, pltData, sizeof(pltData));
 
-  uint64_t got = in.gotPlt->getVA();
-  uint64_t plt = in.plt->getVA();
+  uint64_t got = c.gotPlt->getVA();
+  uint64_t plt = c.plt->getVA();
   relocateNoSym(buf + 4, R_AARCH64_ADR_PREL_PG_HI21,
                 getAArch64Page(got + 16) - getAArch64Page(plt + 4));
   relocateNoSym(buf + 8, R_AARCH64_LDST64_ABS_LO12_NC, got + 16);
   relocateNoSym(buf + 12, R_AARCH64_ADD_ABS_LO12_NC, got + 16);
 }
 
-void AArch64::writePlt(uint8_t *buf, const Symbol &sym,
+void AArch64::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                        uint64_t pltEntryAddr) const {
   const uint8_t inst[] = {
       0x10, 0x00, 0x00, 0x90, // adrp x16, Page(&(.got.plt[n]))
@@ -269,7 +270,7 @@ void AArch64::writePlt(uint8_t *buf, const Symbol &sym,
   };
   memcpy(buf, inst, sizeof(inst));
 
-  uint64_t gotPltEntryAddr = sym.getGotPltVA();
+  uint64_t gotPltEntryAddr = sym.getGotPltVA(c);
   relocateNoSym(buf, R_AARCH64_ADR_PREL_PG_HI21,
                 getAArch64Page(gotPltEntryAddr) - getAArch64Page(pltEntryAddr));
   relocateNoSym(buf + 4, R_AARCH64_LDST64_ABS_LO12_NC, gotPltEntryAddr);
@@ -277,13 +278,13 @@ void AArch64::writePlt(uint8_t *buf, const Symbol &sym,
 }
 
 bool AArch64::needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                         uint64_t branchAddr, const Symbol &s,
-                         int64_t a) const {
+                         const Compartment &c, uint64_t branchAddr,
+                         const Symbol &s, int64_t a) const {
   // If s is an undefined weak symbol and does not have a PLT entry then it will
   // be resolved as a branch to the next instruction. If it is hidden, its
   // binding has been converted to local, so we just check isUndefined() here. A
   // undefined non-weak symbol will have been errored.
-  if (s.isUndefined() && !s.isInPlt())
+  if (s.isUndefined() && !s.isInPlt(c))
     return false;
   // ELF for the ARM 64-bit architecture, section Call and Jump relocations
   // only permits range extension thunks for R_AARCH64_CALL26 and
@@ -291,7 +292,7 @@ bool AArch64::needsThunk(RelExpr expr, RelType type, const InputFile *file,
   if (type != R_AARCH64_CALL26 && type != R_AARCH64_JUMP26 &&
       type != R_AARCH64_PLT32)
     return false;
-  uint64_t dst = expr == R_PLT_PC ? s.getPltVA() : s.getVA(a);
+  uint64_t dst = expr == R_PLT_PC ? s.getPltVA(c) : s.getVA(a);
   return !inBranchRange(type, branchAddr, dst);
 }
 
@@ -827,8 +828,8 @@ namespace {
 class AArch64BtiPac final : public AArch64 {
 public:
   AArch64BtiPac();
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
 
 private:
@@ -856,7 +857,7 @@ AArch64BtiPac::AArch64BtiPac() {
   }
 }
 
-void AArch64BtiPac::writePltHeader(uint8_t *buf) const {
+void AArch64BtiPac::writePltHeader(Compartment &c, uint8_t *buf) const {
   const uint8_t btiData[] = { 0x5f, 0x24, 0x03, 0xd5 }; // bti c
   const uint8_t pltData[] = {
       0xf0, 0x7b, 0xbf, 0xa9, // stp    x16, x30, [sp,#-16]!
@@ -869,8 +870,8 @@ void AArch64BtiPac::writePltHeader(uint8_t *buf) const {
   };
   const uint8_t nopData[] = { 0x1f, 0x20, 0x03, 0xd5 }; // nop
 
-  uint64_t got = in.gotPlt->getVA();
-  uint64_t plt = in.plt->getVA();
+  uint64_t got = c.gotPlt->getVA();
+  uint64_t plt = c.plt->getVA();
 
   if (btiHeader) {
     // PltHeader is called indirectly by plt[N]. Prefix pltData with a BTI C
@@ -890,7 +891,7 @@ void AArch64BtiPac::writePltHeader(uint8_t *buf) const {
     memcpy(buf + sizeof(pltData), nopData, sizeof(nopData));
 }
 
-void AArch64BtiPac::writePlt(uint8_t *buf, const Symbol &sym,
+void AArch64BtiPac::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                              uint64_t pltEntryAddr) const {
   // The PLT entry is of the form:
   // [btiData] addrInst (pacBr | stdBr) [nopData]
@@ -915,15 +916,16 @@ void AArch64BtiPac::writePlt(uint8_t *buf, const Symbol &sym,
   // address may escape if referenced by a direct relocation. If relative
   // vtables are used then if the vtable is in a shared object the offsets will
   // be to the PLT entry. The condition is conservative.
+  const SymbolCompartAux &aux = sym.compartAux(c);
   bool hasBti = btiHeader &&
-                (sym.hasFlag(NEEDS_COPY) || sym.isInIplt || sym.thunkAccessed);
+                (aux.hasFlag(NEEDS_COPY) || aux.isInIplt || sym.thunkAccessed);
   if (hasBti) {
     memcpy(buf, btiData, sizeof(btiData));
     buf += sizeof(btiData);
     pltEntryAddr += sizeof(btiData);
   }
 
-  uint64_t gotPltEntryAddr = sym.getGotPltVA();
+  uint64_t gotPltEntryAddr = sym.getGotPltVA(c);
   memcpy(buf, addrInst, sizeof(addrInst));
   relocateNoSym(buf, R_AARCH64_ADR_PREL_PG_HI21,
                 getAArch64Page(gotPltEntryAddr) - getAArch64Page(pltEntryAddr));

--- a/lld/ELF/Arch/ARM.cpp
+++ b/lld/ELF/Arch/ARM.cpp
@@ -34,15 +34,16 @@ public:
                      const uint8_t *loc) const override;
   RelType getDynRel(RelType type) const override;
   int64_t getImplicitAddend(const uint8_t *buf, RelType type) const override;
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
   void writeIgotPlt(uint8_t *buf, const Symbol &s) const override;
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
   void addPltSymbols(InputSection &isec, uint64_t off) const override;
   void addPltHeaderSymbols(InputSection &isd) const override;
   bool needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                  uint64_t branchAddr, const Symbol &s,
+                  const Compartment &c, uint64_t branchAddr, const Symbol &s,
                   int64_t a) const override;
   uint32_t getThunkSectionSpacing() const override;
   bool inBranchRange(RelType type, uint64_t src, uint64_t dst) const override;
@@ -203,8 +204,8 @@ RelType ARM::getDynRel(RelType type) const {
   return R_ARM_NONE;
 }
 
-void ARM::writeGotPlt(uint8_t *buf, const Symbol &) const {
-  write32(buf, in.plt->getVA());
+void ARM::writeGotPlt(Compartment &c, uint8_t *buf, const Symbol &) const {
+  write32(buf, c.plt->getVA());
 }
 
 void ARM::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
@@ -214,7 +215,7 @@ void ARM::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
 
 // Long form PLT Header that does not have any restrictions on the displacement
 // of the .plt from the .got.plt.
-static void writePltHeaderLong(uint8_t *buf) {
+static void writePltHeaderLong(Compartment &c, uint8_t *buf) {
   write32(buf + 0, 0xe52de004);   //     str lr, [sp,#-4]!
   write32(buf + 4, 0xe59fe004);   //     ldr lr, L2
   write32(buf + 8, 0xe08fe00e);   // L1: add lr, pc, lr
@@ -223,14 +224,14 @@ static void writePltHeaderLong(uint8_t *buf) {
   write32(buf + 20, 0xd4d4d4d4);  //     Pad to 32-byte boundary
   write32(buf + 24, 0xd4d4d4d4);  //     Pad to 32-byte boundary
   write32(buf + 28, 0xd4d4d4d4);
-  uint64_t gotPlt = in.gotPlt->getVA();
-  uint64_t l1 = in.plt->getVA() + 8;
+  uint64_t gotPlt = c.gotPlt->getVA();
+  uint64_t l1 = c.plt->getVA() + 8;
   write32(buf + 16, gotPlt - l1 - 8);
 }
 
 // The default PLT header requires the .got.plt to be within 128 Mb of the
 // .plt in the positive direction.
-void ARM::writePltHeader(uint8_t *buf) const {
+void ARM::writePltHeader(Compartment &c, uint8_t *buf) const {
   // Use a similar sequence to that in writePlt(), the difference is the calling
   // conventions mean we use lr instead of ip. The PLT entry is responsible for
   // saving lr on the stack, the dynamic loader is responsible for reloading
@@ -242,10 +243,10 @@ void ARM::writePltHeader(uint8_t *buf) const {
       0xe5bef000, //     ldr pc, [lr, #0x00000NNN] &(.got.plt -L1 - 4)
   };
 
-  uint64_t offset = in.gotPlt->getVA() - in.plt->getVA() - 4;
+  uint64_t offset = c.gotPlt->getVA() - c.plt->getVA() - 4;
   if (!llvm::isUInt<27>(offset)) {
     // We cannot encode the Offset, use the long form.
-    writePltHeaderLong(buf);
+    writePltHeaderLong(c, buf);
     return;
   }
   write32(buf + 0, pltData[0]);
@@ -277,7 +278,7 @@ static void writePltLong(uint8_t *buf, uint64_t gotPltEntryAddr,
 
 // The default PLT entries require the .got.plt to be within 128 Mb of the
 // .plt in the positive direction.
-void ARM::writePlt(uint8_t *buf, const Symbol &sym,
+void ARM::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                    uint64_t pltEntryAddr) const {
   // The PLT entry is similar to the example given in Appendix A of ELF for
   // the Arm Architecture. Instead of using the Group Relocations to find the
@@ -290,10 +291,10 @@ void ARM::writePlt(uint8_t *buf, const Symbol &sym,
       0xe5bcf000, //     ldr pc, [ip, #0x00000NNN] Offset(&(.got.plt) - L1 - 8
   };
 
-  uint64_t offset = sym.getGotPltVA() - pltEntryAddr - 8;
+  uint64_t offset = sym.getGotPltVA(c) - pltEntryAddr - 8;
   if (!llvm::isUInt<27>(offset)) {
     // We cannot encode the Offset, use the long form.
-    writePltLong(buf, sym.getGotPltVA(), pltEntryAddr);
+    writePltLong(buf, sym.getGotPltVA(c), pltEntryAddr);
     return;
   }
   write32(buf + 0, pltData[0] | ((offset >> 20) & 0xff));
@@ -308,13 +309,13 @@ void ARM::addPltSymbols(InputSection &isec, uint64_t off) const {
 }
 
 bool ARM::needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                     uint64_t branchAddr, const Symbol &s,
+                     const Compartment &c, uint64_t branchAddr, const Symbol &s,
                      int64_t a) const {
   // If s is an undefined weak symbol and does not have a PLT entry then it will
   // be resolved as a branch to the next instruction. If it is hidden, its
   // binding has been converted to local, so we just check isUndefined() here. A
   // undefined non-weak symbol will have been errored.
-  if (s.isUndefined() && !s.isInPlt())
+  if (s.isUndefined() && !s.isInPlt(c))
     return false;
   // A state change from ARM to Thumb and vice versa must go through an
   // interworking thunk if the relocation type is not R_ARM_CALL or
@@ -329,7 +330,7 @@ bool ARM::needsThunk(RelExpr expr, RelType type, const InputFile *file,
       return true;
     [[fallthrough]];
   case R_ARM_CALL: {
-    uint64_t dst = (expr == R_PLT_PC) ? s.getPltVA() : s.getVA();
+    uint64_t dst = (expr == R_PLT_PC) ? s.getPltVA(c) : s.getVA();
     return !inBranchRange(type, branchAddr, dst + a) ||
         (!config->armHasBlx && (s.getVA() & 1));
   }
@@ -341,7 +342,7 @@ bool ARM::needsThunk(RelExpr expr, RelType type, const InputFile *file,
       return true;
     [[fallthrough]];
   case R_ARM_THM_CALL: {
-    uint64_t dst = (expr == R_PLT_PC) ? s.getPltVA() : s.getVA();
+    uint64_t dst = (expr == R_PLT_PC) ? s.getPltVA(c) : s.getVA();
     return !inBranchRange(type, branchAddr, dst + a) ||
         (!config->armHasBlx && (s.getVA() & 1) == 0);;
   }
@@ -609,9 +610,9 @@ void ARM::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
     bool isBlx = (read16(loc + 2) & 0x1000) == 0;
     // lld 10.0 and before always used bit0Thumb when deciding to write a BLX
     // even when type not STT_FUNC. PLT entries generated by LLD are always ARM.
-    if (!rel.sym->isFunc() && !rel.sym->isInPlt() && isBlx == bit0Thumb)
+    if (!rel.sym->isFunc() && !rel.sym->isInAnyPlt() && isBlx == bit0Thumb)
       stateChangeWarning(loc, rel.type, *rel.sym);
-    if (rel.sym->isFunc() || rel.sym->isInPlt() ? !bit0Thumb : isBlx) {
+    if (rel.sym->isFunc() || rel.sym->isInAnyPlt() ? !bit0Thumb : isBlx) {
       // We are writing a BLX. Ensure BLX destination is 4-byte aligned. As
       // the BLX instruction may only be two byte aligned. This must be done
       // before overflow check.

--- a/lld/ELF/Arch/AVR.cpp
+++ b/lld/ELF/Arch/AVR.cpp
@@ -48,7 +48,7 @@ public:
   RelExpr getRelExpr(RelType type, const Symbol &s,
                      const uint8_t *loc) const override;
   bool needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                  uint64_t branchAddr, const Symbol &s,
+                  const Compartment &c, uint64_t branchAddr, const Symbol &s,
                   int64_t a) const override;
   void relocate(uint8_t *loc, const Relocation &rel,
                 uint64_t val) const override;
@@ -104,7 +104,8 @@ static void writeLDI(uint8_t *loc, uint64_t val) {
 }
 
 bool AVR::needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                     uint64_t branchAddr, const Symbol &s, int64_t a) const {
+                     const Compartment &c, uint64_t branchAddr, const Symbol &s,
+                     int64_t a) const {
   switch (type) {
   case R_AVR_LO8_LDI_GS:
   case R_AVR_HI8_LDI_GS:

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -512,10 +512,19 @@ void CheriCapRelocsSection::writeToImpl(uint8_t *buf) {
     uint64_t permissions = CapRelocPermission<ELFT>::encodeType(targetType);
 
     // Use PCC bounds from the PT_CHERI_PCC segment.
-    if (PhdrEntry *ph = in.cheriBounds; ph && isCapRelocTypeExec(targetType)) {
-      targetOffset += targetVA - ph->p_vaddr;
-      targetVA = ph->p_vaddr;
-      targetSize = ph->p_memsz;
+    if (isCapRelocTypeExec(targetType)) {
+      Compartment *c;
+      if (Symbol *s = dyn_cast<Symbol *>(realTarget.symOrSec))
+        c = s->containingCompartment();
+      else {
+        InputSectionBase *isec = cast<InputSectionBase *>(realTarget.symOrSec);
+        c = &isec->getCompartment();
+      }
+      if (PhdrEntry *ph = c->cheriBounds) {
+        targetOffset += targetVA - ph->p_vaddr;
+        targetVA = ph->p_vaddr;
+        targetSize = ph->p_memsz;
+      }
     }
 
     // TODO: should we warn about symbols that are out-of-bounds?
@@ -806,8 +815,9 @@ uint64_t MipsCheriCapTableSection::assignIndices(uint64_t startIndex,
     // All capability call relocations should end up in the pltrel section
     // rather than the normal relocation section to make processing of PLT
     // relocations in RTLD more efficient.
-    RelocationBaseSection &dynRelSec =
-        it.second.usedInCallExpr ? *in.relaPlt : *mainPart->relaDyn;
+    RelocationBaseSection &dynRelSec = it.second.usedInCallExpr
+                                           ? *getCompartment().relaPlt
+                                           : *mainPart->relaDyn;
     if (targetSym->isPreemptible)
       dynRelSec.addSymbolReloc(elfCapabilityReloc, *this, off, *targetSym);
     else if (targetSym->isUndefWeak())
@@ -940,7 +950,7 @@ void MipsCheriCapTableMappingSection::writeTo(uint8_t *buf) {
   // Write the mapping from function vaddr -> captable subset for RTLD
   std::vector<CaptableMappingEntry> entries;
   // Note: Symtab->getSymbols() only returns the symbols in .dynsym. We need
-  // to use In.sym()tab instead since we also want to add all local functions!
+  // to use in.symTab instead since we also want to add all local functions!
   for (const SymbolTableEntry &ste : in.symTab->getSymbols()) {
     Symbol* sym = ste.sym;
     if (!sym->isDefined() || !sym->isFunc())
@@ -1036,8 +1046,9 @@ static bool alignPCCBounds(PhdrEntry *p, CheriPccPaddingSection &psec) {
 bool cheriCapabilityBoundsAlign() {
   // Align the PT_CHERI_PCC segment.
   bool changed = false;
-  if (in.cheriBounds)
-    changed |= alignPCCBounds(in.cheriBounds, *in.pccPadding);
+  for (Compartment &compart : compartments)
+    if (compart.cheriBounds)
+      changed |= alignPCCBounds(compart.cheriBounds, *compart.pccPadding);
   return changed;
 }
 

--- a/lld/ELF/Arch/Hexagon.cpp
+++ b/lld/ELF/Arch/Hexagon.cpp
@@ -31,8 +31,8 @@ public:
   RelType getDynRel(RelType type) const override;
   void relocate(uint8_t *loc, const Relocation &rel,
                 uint64_t val) const override;
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
 };
 } // namespace
@@ -346,7 +346,7 @@ void Hexagon::relocate(uint8_t *loc, const Relocation &rel,
   }
 }
 
-void Hexagon::writePltHeader(uint8_t *buf) const {
+void Hexagon::writePltHeader(Compartment &c, uint8_t *buf) const {
   const uint8_t pltData[] = {
       0x00, 0x40, 0x00, 0x00, // { immext (#0)
       0x1c, 0xc0, 0x49, 0x6a, //   r28 = add (pc, ##GOT0@PCREL) } # @GOT0
@@ -360,12 +360,12 @@ void Hexagon::writePltHeader(uint8_t *buf) const {
   memcpy(buf, pltData, sizeof(pltData));
 
   // Offset from PLT0 to the GOT.
-  uint64_t off = in.gotPlt->getVA() - in.plt->getVA();
+  uint64_t off = c.gotPlt->getVA() - c.plt->getVA();
   relocateNoSym(buf, R_HEX_B32_PCREL_X, off);
   relocateNoSym(buf + 4, R_HEX_6_PCREL_X, off);
 }
 
-void Hexagon::writePlt(uint8_t *buf, const Symbol &sym,
+void Hexagon::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                        uint64_t pltEntryAddr) const {
   const uint8_t inst[] = {
       0x00, 0x40, 0x00, 0x00, // { immext (#0)
@@ -375,7 +375,7 @@ void Hexagon::writePlt(uint8_t *buf, const Symbol &sym,
   };
   memcpy(buf, inst, sizeof(inst));
 
-  uint64_t gotPltEntryAddr = sym.getGotPltVA();
+  uint64_t gotPltEntryAddr = sym.getGotPltVA(c);
   relocateNoSym(buf, R_HEX_B32_PCREL_X, gotPltEntryAddr - pltEntryAddr);
   relocateNoSym(buf + 4, R_HEX_6_PCREL_X, gotPltEntryAddr - pltEntryAddr);
 }

--- a/lld/ELF/Arch/LoongArch.cpp
+++ b/lld/ELF/Arch/LoongArch.cpp
@@ -25,10 +25,11 @@ public:
   LoongArch();
   uint32_t calcEFlags() const override;
   int64_t getImplicitAddend(const uint8_t *buf, RelType type) const override;
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
   void writeIgotPlt(uint8_t *buf, const Symbol &s) const override;
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
   RelType getDynRel(RelType type) const override;
   RelExpr getRelExpr(RelType type, const Symbol &s,
@@ -338,11 +339,12 @@ int64_t LoongArch::getImplicitAddend(const uint8_t *buf, RelType type) const {
   }
 }
 
-void LoongArch::writeGotPlt(uint8_t *buf, const Symbol &s) const {
+void LoongArch::writeGotPlt(Compartment &c, uint8_t *buf,
+                            const Symbol &s) const {
   if (config->is64)
-    write64le(buf, in.plt->getVA());
+    write64le(buf, c.plt->getVA());
   else
-    write32le(buf, in.plt->getVA());
+    write32le(buf, c.plt->getVA());
 }
 
 void LoongArch::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
@@ -354,7 +356,7 @@ void LoongArch::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
   }
 }
 
-void LoongArch::writePltHeader(uint8_t *buf) const {
+void LoongArch::writePltHeader(Compartment &c, uint8_t *buf) const {
   // The LoongArch PLT is currently structured just like that of RISCV.
   // Annoyingly, this means the PLT is still using `pcaddu12i` to perform
   // PC-relative addressing (because `pcaddu12i` is the same as RISCV `auipc`),
@@ -373,7 +375,7 @@ void LoongArch::writePltHeader(uint8_t *buf) const {
   //   srli.[wd] $t1, $t1, (is64?1:2)             ; t1 = &.got.plt[i] - &.got.plt[0]
   //   ld.[wd]   $t0, $t0, Wordsize               ; t0 = link_map
   //   jr        $t3
-  uint32_t offset = in.gotPlt->getVA() - in.plt->getVA();
+  uint32_t offset = c.gotPlt->getVA() - c.plt->getVA();
   uint32_t sub = config->is64 ? SUB_D : SUB_W;
   uint32_t ld = config->is64 ? LD_D : LD_W;
   uint32_t addi = config->is64 ? ADDI_D : ADDI_W;
@@ -388,8 +390,8 @@ void LoongArch::writePltHeader(uint8_t *buf) const {
   write32le(buf + 28, insn(JIRL, R_ZERO, R_T3, 0));
 }
 
-void LoongArch::writePlt(uint8_t *buf, const Symbol &sym,
-                     uint64_t pltEntryAddr) const {
+void LoongArch::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
+                         uint64_t pltEntryAddr) const {
   // See the comment in writePltHeader for reason why pcaddu12i is used instead
   // of the pcalau12i that's more commonly seen in the ELF psABI v2.0 days.
   //
@@ -397,7 +399,7 @@ void LoongArch::writePlt(uint8_t *buf, const Symbol &sym,
   //   ld.[wd]   $t3, $t3, %pcrel_lo12(f@.got.plt)
   //   jirl      $t1, $t3, 0
   //   nop
-  uint32_t offset = sym.getGotPltVA() - pltEntryAddr;
+  uint32_t offset = sym.getGotPltVA(c) - pltEntryAddr;
   write32le(buf + 0, insn(PCADDU12I, R_T3, hi20(offset), 0));
   write32le(buf + 4,
             insn(config->is64 ? LD_D : LD_W, R_T3, R_T3, lo12(offset)));

--- a/lld/ELF/Arch/Mips.cpp
+++ b/lld/ELF/Arch/Mips.cpp
@@ -32,12 +32,13 @@ public:
                      const uint8_t *loc) const override;
   int64_t getImplicitAddend(const uint8_t *buf, RelType type) const override;
   RelType getDynRel(RelType type) const override;
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
   bool needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                  uint64_t branchAddr, const Symbol &s,
+                  const Compartment &c, uint64_t branchAddr, const Symbol &s,
                   int64_t a) const override;
   void relocate(uint8_t *loc, const Relocation &rel,
                 uint64_t val) const override;
@@ -254,8 +255,9 @@ template <class ELFT> RelType MIPS<ELFT>::getDynRel(RelType type) const {
 }
 
 template <class ELFT>
-void MIPS<ELFT>::writeGotPlt(uint8_t *buf, const Symbol &) const {
-  uint64_t va = in.plt->getVA();
+void MIPS<ELFT>::writeGotPlt(Compartment &c, uint8_t *buf,
+                             const Symbol &) const {
+  uint64_t va = c.plt->getVA();
   if (isMicroMips())
     va |= 1;
   write32(buf, va);
@@ -305,10 +307,11 @@ static void writeMicroRelocation16(uint8_t *loc, uint64_t v, uint8_t bitsSize,
   write16(loc, data);
 }
 
-template <class ELFT> void MIPS<ELFT>::writePltHeader(uint8_t *buf) const {
+template <class ELFT>
+void MIPS<ELFT>::writePltHeader(Compartment &c, uint8_t *buf) const {
   if (isMicroMips()) {
-    uint64_t gotPlt = in.gotPlt->getVA();
-    uint64_t plt = in.plt->getVA();
+    uint64_t gotPlt = c.gotPlt->getVA();
+    uint64_t plt = c.plt->getVA();
     // Overwrite trap instructions written by Writer::writeTrapInstr.
     memset(buf, 0, pltHeaderSize);
 
@@ -360,16 +363,16 @@ template <class ELFT> void MIPS<ELFT>::writePltHeader(uint8_t *buf) const {
   write32(buf + 24, jalrInst); // jalr.hb $25 or jalr $25
   write32(buf + 28, 0x2718fffe); // subu  $24, $24, 2
 
-  uint64_t gotPlt = in.gotPlt->getVA();
+  uint64_t gotPlt = c.gotPlt->getVA();
   writeValue(buf, gotPlt + 0x8000, 16, 16);
   writeValue(buf + 4, gotPlt, 16, 0);
   writeValue(buf + 8, gotPlt, 16, 0);
 }
 
 template <class ELFT>
-void MIPS<ELFT>::writePlt(uint8_t *buf, const Symbol &sym,
+void MIPS<ELFT>::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                           uint64_t pltEntryAddr) const {
-  uint64_t gotPltEntryAddr = sym.getGotPltVA();
+  uint64_t gotPltEntryAddr = sym.getGotPltVA(c);
   if (isMicroMips()) {
     // Overwrite trap instructions written by Writer::writeTrapInstr.
     memset(buf, 0, pltEntrySize);
@@ -406,8 +409,8 @@ void MIPS<ELFT>::writePlt(uint8_t *buf, const Symbol &sym,
 
 template <class ELFT>
 bool MIPS<ELFT>::needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                            uint64_t branchAddr, const Symbol &s,
-                            int64_t /*a*/) const {
+                            const Compartment &c, uint64_t branchAddr,
+                            const Symbol &s, int64_t /*a*/) const {
   // Any MIPS PIC code function is invoked with its address in register $t9.
   // So if we have a branch instruction from non-PIC code to the PIC one
   // we cannot make the jump directly and need to create a small stubs

--- a/lld/ELF/Arch/PPC.cpp
+++ b/lld/ELF/Arch/PPC.cpp
@@ -32,18 +32,19 @@ public:
   RelType getDynRel(RelType type) const override;
   int64_t getImplicitAddend(const uint8_t *buf, RelType type) const override;
   void writeGotHeader(uint8_t *buf) const override;
-  void writePltHeader(uint8_t *buf) const override {
+  void writePltHeader(Compartment &c, uint8_t *buf) const override {
     llvm_unreachable("should call writePPC32GlinkSection() instead");
   }
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override {
     llvm_unreachable("should call writePPC32GlinkSection() instead");
   }
-  void writeIplt(uint8_t *buf, const Symbol &sym,
+  void writeIplt(Compartment &c, uint8_t *buf, const Symbol &sym,
                  uint64_t pltEntryAddr) const override;
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
   bool needsThunk(RelExpr expr, RelType relocType, const InputFile *file,
-                  uint64_t branchAddr, const Symbol &s,
+                  const Compartment &c, uint64_t branchAddr, const Symbol &s,
                   int64_t a) const override;
   uint32_t getThunkSectionSpacing() const override;
   bool inBranchRange(RelType type, uint64_t src, uint64_t dst) const override;
@@ -72,13 +73,14 @@ static void writeFromHalf16(uint8_t *loc, uint32_t insn) {
   write32(config->isLE ? loc : loc - 2, insn);
 }
 
-void elf::writePPC32GlinkSection(uint8_t *buf, size_t numEntries) {
+void elf::writePPC32GlinkSection(Compartment &c, uint8_t *buf,
+                                 size_t numEntries) {
   // Create canonical PLT entries for non-PIE code. Compilers don't generate
   // non-GOT-non-PLT relocations referencing external functions for -fpie/-fPIE.
-  uint32_t glink = in.plt->getVA(); // VA of .glink
+  uint32_t glink = c.plt->getVA(); // VA of .glink
   if (!config->isPic) {
-    for (const Symbol *sym : cast<PPC32GlinkSection>(*in.plt).canonical_plts) {
-      writePPC32PltCallStub(buf, sym->getGotPltVA(), nullptr, 0);
+    for (const Symbol *sym : cast<PPC32GlinkSection>(*c.plt).canonical_plts) {
+      writePPC32PltCallStub(buf, sym->getGotPltVA(c), nullptr, c, 0);
       buf += 16;
       glink += 16;
     }
@@ -101,10 +103,10 @@ void elf::writePPC32GlinkSection(uint8_t *buf, size_t numEntries) {
   // Then write PLTresolve(), which has two forms: PIC and non-PIC. PLTresolve()
   // computes the PLT index (by computing the distance from the landing b to
   // itself) and calls _dl_runtime_resolve() (in glibc).
-  uint32_t got = in.got->getVA();
+  uint32_t got = c.got->getVA();
   const uint8_t *end = buf + 64;
   if (config->isPic) {
-    uint32_t afterBcl = 4 * in.plt->getNumEntries() + 12;
+    uint32_t afterBcl = 4 * c.plt->getNumEntries() + 12;
     uint32_t gotBcl = got + 4 - (glink + afterBcl);
     write32(buf + 0, 0x3d6b0000 | ha(afterBcl));  // addis r11,r11,1f-glink@ha
     write32(buf + 4, 0x7c0802a6);                 // mflr r0
@@ -176,11 +178,11 @@ PPC::PPC() {
   write32(trapInstr.data(), 0x7fe00008);
 }
 
-void PPC::writeIplt(uint8_t *buf, const Symbol &sym,
+void PPC::writeIplt(Compartment &c, uint8_t *buf, const Symbol &sym,
                     uint64_t /*pltEntryAddr*/) const {
   // In -pie or -shared mode, assume r30 points to .got2+0x8000, and use a
   // .got2.plt_pic32. thunk.
-  writePPC32PltCallStub(buf, sym.getGotPltVA(), sym.file, 0x8000);
+  writePPC32PltCallStub(buf, sym.getGotPltVA(c), sym.file, c, 0x8000);
 }
 
 void PPC::writeGotHeader(uint8_t *buf) const {
@@ -190,16 +192,17 @@ void PPC::writeGotHeader(uint8_t *buf) const {
   write32(buf, mainPart->dynamic->getVA());
 }
 
-void PPC::writeGotPlt(uint8_t *buf, const Symbol &s) const {
+void PPC::writeGotPlt(Compartment &c, uint8_t *buf, const Symbol &s) const {
   // Address of the symbol resolver stub in .glink .
-  write32(buf, in.plt->getVA() + in.plt->headerSize + 4 * s.getPltIdx());
+  write32(buf, c.plt->getVA() + c.plt->headerSize + 4 * s.getPltIdx(c));
 }
 
 bool PPC::needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                     uint64_t branchAddr, const Symbol &s, int64_t a) const {
+                     const Compartment &c, uint64_t branchAddr, const Symbol &s,
+                     int64_t a) const {
   if (type != R_PPC_LOCAL24PC && type != R_PPC_REL24 && type != R_PPC_PLTREL24)
     return false;
-  if (s.isInPlt())
+  if (s.isInPlt(c))
     return true;
   if (s.isUndefWeak())
     return false;

--- a/lld/ELF/Arch/PPC64.cpp
+++ b/lld/ELF/Arch/PPC64.cpp
@@ -329,9 +329,10 @@ getRelaTocSymAndAddend(InputSectionBase *tocSec, uint64_t offset) {
   if (relas.empty())
     return {};
   uint64_t index = std::min<uint64_t>(offset / 8, relas.size() - 1);
+  const Compartment &c = tocSec->getCompartment();
   for (;;) {
     if (relas[index].r_offset == offset) {
-      Symbol &sym = tocSec->getFile<ELFT>()->getRelocTargetSym(relas[index]);
+      Symbol &sym = tocSec->getFile<ELFT>()->getRelocTargetSym(c, relas[index]);
       return {dyn_cast<Defined>(&sym), getAddend<ELFT>(relas[index])};
     }
     if (relas[index].r_offset < offset || index == 0)

--- a/lld/ELF/Arch/PPC64.cpp
+++ b/lld/ELF/Arch/PPC64.cpp
@@ -159,16 +159,16 @@ public:
                      const uint8_t *loc) const override;
   RelType getDynRel(RelType type) const override;
   int64_t getImplicitAddend(const uint8_t *buf, RelType type) const override;
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
-  void writeIplt(uint8_t *buf, const Symbol &sym,
+  void writeIplt(Compartment &c, uint8_t *buf, const Symbol &sym,
                  uint64_t pltEntryAddr) const override;
   void relocate(uint8_t *loc, const Relocation &rel,
                 uint64_t val) const override;
   void writeGotHeader(uint8_t *buf) const override;
   bool needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                  uint64_t branchAddr, const Symbol &s,
+                  const Compartment &c, uint64_t branchAddr, const Symbol &s,
                   int64_t a) const override;
   uint32_t getThunkSectionSpacing() const override;
   bool inBranchRange(RelType type, uint64_t src, uint64_t dst) const override;
@@ -194,7 +194,7 @@ uint64_t elf::getPPC64TocBase() {
   // TOC starts where the first of these sections starts. We always create a
   // .got when we see a relocation that uses it, so for us the start is always
   // the .got.
-  uint64_t tocVA = in.got->getVA();
+  uint64_t tocVA = defaultCompart->got->getVA();
 
   // Per the ppc64-elf-linux ABI, The TOC base is TOC value plus 0x8000
   // thus permitting a full 64 Kbytes segment. Note that the glibc startup
@@ -1089,7 +1089,7 @@ void PPC64::writeGotHeader(uint8_t *buf) const {
   write64(buf, getPPC64TocBase());
 }
 
-void PPC64::writePltHeader(uint8_t *buf) const {
+void PPC64::writePltHeader(Compartment &c, uint8_t *buf) const {
   // The generic resolver stub goes first.
   write32(buf +  0, 0x7c0802a6); // mflr r0
   write32(buf +  4, 0x429f0005); // bcl  20,4*cr7+so,8 <_glink+0x8>
@@ -1108,20 +1108,20 @@ void PPC64::writePltHeader(uint8_t *buf) const {
   // The 'bcl' instruction will set the link register to the address of the
   // following instruction ('mflr r11'). Here we store the offset from that
   // instruction  to the first entry in the GotPlt section.
-  int64_t gotPltOffset = in.gotPlt->getVA() - (in.plt->getVA() + 8);
+  int64_t gotPltOffset = c.gotPlt->getVA() - (c.plt->getVA() + 8);
   write64(buf + 52, gotPltOffset);
 }
 
-void PPC64::writePlt(uint8_t *buf, const Symbol &sym,
+void PPC64::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                      uint64_t /*pltEntryAddr*/) const {
-  int32_t offset = pltHeaderSize + sym.getPltIdx() * pltEntrySize;
+  int32_t offset = pltHeaderSize + sym.getPltIdx(c) * pltEntrySize;
   // bl __glink_PLTresolve
   write32(buf, 0x48000000 | ((-offset) & 0x03FFFFFc));
 }
 
-void PPC64::writeIplt(uint8_t *buf, const Symbol &sym,
+void PPC64::writeIplt(Compartment &c, uint8_t *buf, const Symbol &sym,
                       uint64_t /*pltEntryAddr*/) const {
-  writePPC64LoadAndBranch(buf, sym.getGotPltVA() - getPPC64TocBase());
+  writePPC64LoadAndBranch(buf, sym.getGotPltVA(c) - getPPC64TocBase());
 }
 
 static std::pair<RelType, uint64_t> toAddr16Rel(RelType type, uint64_t val) {
@@ -1376,13 +1376,14 @@ void PPC64::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
 }
 
 bool PPC64::needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                       uint64_t branchAddr, const Symbol &s, int64_t a) const {
+                       const Compartment &c, uint64_t branchAddr,
+                       const Symbol &s, int64_t a) const {
   if (type != R_PPC64_REL14 && type != R_PPC64_REL24 &&
       type != R_PPC64_REL24_NOTOC)
     return false;
 
   // If a function is in the Plt it needs to be called with a call-stub.
-  if (s.isInPlt())
+  if (s.isInPlt(c))
     return true;
 
   // This check looks at the st_other bits of the callee with relocation

--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -36,10 +36,11 @@ public:
   uint64_t getCheriRequiredAlignment(uint64_t len) const override;
   int64_t getImplicitAddend(const uint8_t *buf, RelType type) const override;
   void writeGotHeader(uint8_t *buf) const override;
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
   void writeIgotPlt(uint8_t *buf, const Symbol &s) const override;
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
   RelType getDynRel(RelType type) const override;
   RelExpr getRelExpr(RelType type, const Symbol &s,
@@ -235,15 +236,15 @@ void RISCV::writeGotHeader(uint8_t *buf) const {
     write32le(buf, mainPart->dynamic->getVA());
 }
 
-void RISCV::writeGotPlt(uint8_t *buf, const Symbol &s) const {
+void RISCV::writeGotPlt(Compartment &c, uint8_t *buf, const Symbol &s) const {
   // Initialised by __cap_relocs for CHERI
   if (config->isCheriAbi)
     return;
 
   if (config->is64)
-    write64le(buf, in.plt->getVA());
+    write64le(buf, c.plt->getVA());
   else
-    write32le(buf, in.plt->getVA());
+    write32le(buf, c.plt->getVA());
 }
 
 void RISCV::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
@@ -255,7 +256,7 @@ void RISCV::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
   }
 }
 
-void RISCV::writePltHeader(uint8_t *buf) const {
+void RISCV::writePltHeader(Compartment &c, uint8_t *buf) const {
   // 1: auipc(c) (c)t2, %pcrel_hi(.got.plt)
   // (c)sub t1, (c)t1, (c)t3
   // l[wdc] (c)t3, %pcrel_lo(1b)((c)t2); (c)t3 = _dl_runtime_resolve
@@ -265,7 +266,7 @@ void RISCV::writePltHeader(uint8_t *buf) const {
   // l[wdc] (c)t0, Ptrsize((c)t0); (c)t0 = link_map
   // (c)jr (c)t3
   // (if shift == 0): nop
-  uint32_t offset = in.gotPlt->getVA() - in.plt->getVA();
+  uint32_t offset = c.gotPlt->getVA() - c.plt->getVA();
   uint32_t ptrload = config->isCheriAbi ? config->is64 ? CLC_128 : CLC_64
                                         : config->is64 ? LD : LW;
   uint32_t ptraddi = config->isCheriAbi ? CIncOffsetImm : ADDI;
@@ -286,7 +287,7 @@ void RISCV::writePltHeader(uint8_t *buf) const {
     write32le(buf + 28, itype(ADDI, 0, 0, 0));
 }
 
-void RISCV::writePlt(uint8_t *buf, const Symbol &sym,
+void RISCV::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                      uint64_t pltEntryAddr) const {
   // 1: auipc(c) (c)t3, %pcrel_hi(f@[.got.plt|.got])
   // l[wdc] (c)t3, %pcrel_lo(1b)((c)t3)
@@ -294,7 +295,7 @@ void RISCV::writePlt(uint8_t *buf, const Symbol &sym,
   // nop
   uint32_t ptrload = config->isCheriAbi ? config->is64 ? CLC_128 : CLC_64
                                         : config->is64 ? LD : LW;
-  uint32_t entryva = sym.getGotPltVA();
+  uint32_t entryva = sym.getGotPltVA(c);
   uint32_t offset = entryva - pltEntryAddr;
   write32le(buf + 0, utype(AUIPC, X_T3, hi20(offset)));
   write32le(buf + 4, itype(ptrload, X_T3, X_T3, lo12(offset)));
@@ -719,7 +720,8 @@ static void relaxCall(const InputSection &sec, size_t i, uint64_t loc,
   const uint64_t insnPair = read64le(sec.content().data() + r.offset);
   const uint32_t rd = extractBits(insnPair, 32 + 11, 32 + 7);
   const uint64_t dest =
-      (r.expr == R_PLT_PC ? sym.getPltVA() : sym.getVA()) + r.addend;
+      (r.expr == R_PLT_PC ? sym.getPltVA(sec.getCompartment()) : sym.getVA()) +
+      r.addend;
   const int64_t displace = dest - loc;
 
   if (rvc && isInt<12>(displace) && rd == 0) {

--- a/lld/ELF/Arch/SPARCV9.cpp
+++ b/lld/ELF/Arch/SPARCV9.cpp
@@ -24,7 +24,7 @@ public:
   SPARCV9();
   RelExpr getRelExpr(RelType type, const Symbol &s,
                      const uint8_t *loc) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
   void relocate(uint8_t *loc, const Relocation &rel,
                 uint64_t val) const override;
@@ -174,7 +174,7 @@ void SPARCV9::relocate(uint8_t *loc, const Relocation &rel,
   }
 }
 
-void SPARCV9::writePlt(uint8_t *buf, const Symbol & /*sym*/,
+void SPARCV9::writePlt(Compartment &c, uint8_t *buf, const Symbol & /*sym*/,
                        uint64_t pltEntryAddr) const {
   const uint8_t pltData[] = {
       0x03, 0x00, 0x00, 0x00, // sethi   (. - .PLT0), %g1
@@ -188,7 +188,7 @@ void SPARCV9::writePlt(uint8_t *buf, const Symbol & /*sym*/,
   };
   memcpy(buf, pltData, sizeof(pltData));
 
-  uint64_t off = pltEntryAddr - in.plt->getVA();
+  uint64_t off = pltEntryAddr - c.plt->getVA();
   relocateNoSym(buf, R_SPARC_22, off);
   relocateNoSym(buf + 4, R_SPARC_WDISP19, -(off + 4 - pltEntrySize));
 }

--- a/lld/ELF/Arch/X86.cpp
+++ b/lld/ELF/Arch/X86.cpp
@@ -29,10 +29,11 @@ public:
   int64_t getImplicitAddend(const uint8_t *buf, RelType type) const override;
   void writeGotPltHeader(uint8_t *buf) const override;
   RelType getDynRel(RelType type) const override;
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
   void writeIgotPlt(uint8_t *buf, const Symbol &s) const override;
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
   void relocate(uint8_t *loc, const Relocation &rel,
                 uint64_t val) const override;
@@ -167,10 +168,10 @@ void X86::writeGotPltHeader(uint8_t *buf) const {
   write32le(buf, mainPart->dynamic->getVA());
 }
 
-void X86::writeGotPlt(uint8_t *buf, const Symbol &s) const {
+void X86::writeGotPlt(Compartment &c, uint8_t *buf, const Symbol &s) const {
   // Entries in .got.plt initially points back to the corresponding
   // PLT entries with a fixed offset to skip the first instruction.
-  write32le(buf, s.getPltVA() + 6);
+  write32le(buf, s.getPltVA(c) + 6);
 }
 
 void X86::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
@@ -186,7 +187,7 @@ RelType X86::getDynRel(RelType type) const {
   return type;
 }
 
-void X86::writePltHeader(uint8_t *buf) const {
+void X86::writePltHeader(Compartment &c, uint8_t *buf) const {
   if (config->isPic) {
     const uint8_t v[] = {
         0xff, 0xb3, 0x04, 0x00, 0x00, 0x00, // pushl 4(%ebx)
@@ -203,14 +204,14 @@ void X86::writePltHeader(uint8_t *buf) const {
       0x90, 0x90, 0x90, 0x90, // nop
   };
   memcpy(buf, pltData, sizeof(pltData));
-  uint32_t gotPlt = in.gotPlt->getVA();
+  uint32_t gotPlt = c.gotPlt->getVA();
   write32le(buf + 2, gotPlt + 4);
   write32le(buf + 8, gotPlt + 8);
 }
 
-void X86::writePlt(uint8_t *buf, const Symbol &sym,
+void X86::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                    uint64_t pltEntryAddr) const {
-  unsigned relOff = in.relaPlt->entsize * sym.getPltIdx();
+  unsigned relOff = c.relaPlt->entsize * sym.getPltIdx(c);
   if (config->isPic) {
     const uint8_t inst[] = {
         0xff, 0xa3, 0, 0, 0, 0, // jmp *foo@GOT(%ebx)
@@ -218,7 +219,7 @@ void X86::writePlt(uint8_t *buf, const Symbol &sym,
         0xe9, 0,    0, 0, 0,    // jmp .PLT0@PC
     };
     memcpy(buf, inst, sizeof(inst));
-    write32le(buf + 2, sym.getGotPltVA() - in.gotPlt->getVA());
+    write32le(buf + 2, sym.getGotPltVA(c) - c.gotPlt->getVA());
   } else {
     const uint8_t inst[] = {
         0xff, 0x25, 0, 0, 0, 0, // jmp *foo@GOT
@@ -226,11 +227,11 @@ void X86::writePlt(uint8_t *buf, const Symbol &sym,
         0xe9, 0,    0, 0, 0,    // jmp .PLT0@PC
     };
     memcpy(buf, inst, sizeof(inst));
-    write32le(buf + 2, sym.getGotPltVA());
+    write32le(buf + 2, sym.getGotPltVA(c));
   }
 
   write32le(buf + 7, relOff);
-  write32le(buf + 12, in.plt->getVA() - pltEntryAddr - 16);
+  write32le(buf + 12, c.plt->getVA() - pltEntryAddr - 16);
 }
 
 int64_t X86::getImplicitAddend(const uint8_t *buf, RelType type) const {
@@ -519,10 +520,12 @@ namespace {
 class IntelIBT : public X86 {
 public:
   IntelIBT();
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
-  void writeIBTPlt(uint8_t *buf, size_t numEntries) const override;
+  void writeIBTPlt(Compartment &c, uint8_t *buf,
+                   size_t numEntries) const override;
 
   static const unsigned IBTPltHeaderSize = 16;
 };
@@ -530,13 +533,14 @@ public:
 
 IntelIBT::IntelIBT() { pltHeaderSize = 0; }
 
-void IntelIBT::writeGotPlt(uint8_t *buf, const Symbol &s) const {
+void IntelIBT::writeGotPlt(Compartment &c, uint8_t *buf,
+                           const Symbol &s) const {
   uint64_t va =
-      in.ibtPlt->getVA() + IBTPltHeaderSize + s.getPltIdx() * pltEntrySize;
+      in.ibtPlt->getVA() + IBTPltHeaderSize + s.getPltIdx(c) * pltEntrySize;
   write32le(buf, va);
 }
 
-void IntelIBT::writePlt(uint8_t *buf, const Symbol &sym,
+void IntelIBT::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                         uint64_t /*pltEntryAddr*/) const {
   if (config->isPic) {
     const uint8_t inst[] = {
@@ -545,7 +549,7 @@ void IntelIBT::writePlt(uint8_t *buf, const Symbol &sym,
         0x66, 0x0f, 0x1f, 0x44, 0, 0, // nop
     };
     memcpy(buf, inst, sizeof(inst));
-    write32le(buf + 6, sym.getGotPltVA() - in.gotPlt->getVA());
+    write32le(buf + 6, sym.getGotPltVA(c) - c.gotPlt->getVA());
     return;
   }
 
@@ -555,11 +559,12 @@ void IntelIBT::writePlt(uint8_t *buf, const Symbol &sym,
       0x66, 0x0f, 0x1f, 0x44, 0, 0, // nop
   };
   memcpy(buf, inst, sizeof(inst));
-  write32le(buf + 6, sym.getGotPltVA());
+  write32le(buf + 6, sym.getGotPltVA(c));
 }
 
-void IntelIBT::writeIBTPlt(uint8_t *buf, size_t numEntries) const {
-  writePltHeader(buf);
+void IntelIBT::writeIBTPlt(Compartment &c, uint8_t *buf,
+                           size_t numEntries) const {
+  writePltHeader(c, buf);
   buf += IBTPltHeaderSize;
 
   const uint8_t inst[] = {
@@ -581,18 +586,20 @@ namespace {
 class RetpolinePic : public X86 {
 public:
   RetpolinePic();
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
 };
 
 class RetpolineNoPic : public X86 {
 public:
   RetpolineNoPic();
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
 };
 } // namespace
@@ -603,11 +610,12 @@ RetpolinePic::RetpolinePic() {
   ipltEntrySize = 32;
 }
 
-void RetpolinePic::writeGotPlt(uint8_t *buf, const Symbol &s) const {
-  write32le(buf, s.getPltVA() + 17);
+void RetpolinePic::writeGotPlt(Compartment &c, uint8_t *buf,
+                               const Symbol &s) const {
+  write32le(buf, s.getPltVA(c) + 17);
 }
 
-void RetpolinePic::writePltHeader(uint8_t *buf) const {
+void RetpolinePic::writePltHeader(Compartment &c, uint8_t *buf) const {
   const uint8_t insn[] = {
       0xff, 0xb3, 4,    0,    0,    0,          // 0:    pushl 4(%ebx)
       0x50,                                     // 6:    pushl %eax
@@ -628,9 +636,9 @@ void RetpolinePic::writePltHeader(uint8_t *buf) const {
   memcpy(buf, insn, sizeof(insn));
 }
 
-void RetpolinePic::writePlt(uint8_t *buf, const Symbol &sym,
+void RetpolinePic::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                             uint64_t pltEntryAddr) const {
-  unsigned relOff = in.relaPlt->entsize * sym.getPltIdx();
+  unsigned relOff = c.relaPlt->entsize * sym.getPltIdx(c);
   const uint8_t insn[] = {
       0x50,                            // pushl %eax
       0x8b, 0x83, 0,    0,    0,    0, // mov foo@GOT(%ebx), %eax
@@ -642,9 +650,9 @@ void RetpolinePic::writePlt(uint8_t *buf, const Symbol &sym,
   };
   memcpy(buf, insn, sizeof(insn));
 
-  uint32_t ebx = in.gotPlt->getVA();
-  unsigned off = pltEntryAddr - in.plt->getVA();
-  write32le(buf + 3, sym.getGotPltVA() - ebx);
+  uint32_t ebx = c.gotPlt->getVA();
+  unsigned off = pltEntryAddr - c.plt->getVA();
+  write32le(buf + 3, sym.getGotPltVA(c) - ebx);
   write32le(buf + 8, -off - 12 + 32);
   write32le(buf + 13, -off - 17 + 18);
   write32le(buf + 18, relOff);
@@ -657,11 +665,12 @@ RetpolineNoPic::RetpolineNoPic() {
   ipltEntrySize = 32;
 }
 
-void RetpolineNoPic::writeGotPlt(uint8_t *buf, const Symbol &s) const {
-  write32le(buf, s.getPltVA() + 16);
+void RetpolineNoPic::writeGotPlt(Compartment &c, uint8_t *buf,
+                                 const Symbol &s) const {
+  write32le(buf, s.getPltVA(c) + 16);
 }
 
-void RetpolineNoPic::writePltHeader(uint8_t *buf) const {
+void RetpolineNoPic::writePltHeader(Compartment &c, uint8_t *buf) const {
   const uint8_t insn[] = {
       0xff, 0x35, 0,    0,    0,    0, // 0:    pushl GOTPLT+4
       0x50,                            // 6:    pushl %eax
@@ -682,14 +691,14 @@ void RetpolineNoPic::writePltHeader(uint8_t *buf) const {
   };
   memcpy(buf, insn, sizeof(insn));
 
-  uint32_t gotPlt = in.gotPlt->getVA();
+  uint32_t gotPlt = c.gotPlt->getVA();
   write32le(buf + 2, gotPlt + 4);
   write32le(buf + 8, gotPlt + 8);
 }
 
-void RetpolineNoPic::writePlt(uint8_t *buf, const Symbol &sym,
+void RetpolineNoPic::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                               uint64_t pltEntryAddr) const {
-  unsigned relOff = in.relaPlt->entsize * sym.getPltIdx();
+  unsigned relOff = c.relaPlt->entsize * sym.getPltIdx(c);
   const uint8_t insn[] = {
       0x50,                         // 0:  pushl %eax
       0xa1, 0,    0,    0,    0,    // 1:  mov foo_in_GOT, %eax
@@ -702,8 +711,8 @@ void RetpolineNoPic::writePlt(uint8_t *buf, const Symbol &sym,
   };
   memcpy(buf, insn, sizeof(insn));
 
-  unsigned off = pltEntryAddr - in.plt->getVA();
-  write32le(buf + 2, sym.getGotPltVA());
+  unsigned off = pltEntryAddr - c.plt->getVA();
+  write32le(buf + 2, sym.getGotPltVA(c));
   write32le(buf + 7, -off - 11 + 32);
   write32le(buf + 12, -off - 16 + 17);
   write32le(buf + 17, relOff);

--- a/lld/ELF/Arch/X86_64.cpp
+++ b/lld/ELF/Arch/X86_64.cpp
@@ -30,10 +30,11 @@ public:
                      const uint8_t *loc) const override;
   RelType getDynRel(RelType type) const override;
   void writeGotPltHeader(uint8_t *buf) const override;
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
   void writeIgotPlt(uint8_t *buf, const Symbol &s) const override;
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
   void relocate(uint8_t *loc, const Relocation &rel,
                 uint64_t val) const override;
@@ -369,9 +370,9 @@ void X86_64::writeGotPltHeader(uint8_t *buf) const {
   write64le(buf, mainPart->dynamic->getVA());
 }
 
-void X86_64::writeGotPlt(uint8_t *buf, const Symbol &s) const {
+void X86_64::writeGotPlt(Compartment &c, uint8_t *buf, const Symbol &s) const {
   // See comments in X86::writeGotPlt.
-  write64le(buf, s.getPltVA() + 6);
+  write64le(buf, s.getPltVA(c) + 6);
 }
 
 void X86_64::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
@@ -380,20 +381,20 @@ void X86_64::writeIgotPlt(uint8_t *buf, const Symbol &s) const {
     write64le(buf, s.getVA());
 }
 
-void X86_64::writePltHeader(uint8_t *buf) const {
+void X86_64::writePltHeader(Compartment &c, uint8_t *buf) const {
   const uint8_t pltData[] = {
       0xff, 0x35, 0, 0, 0, 0, // pushq GOTPLT+8(%rip)
       0xff, 0x25, 0, 0, 0, 0, // jmp *GOTPLT+16(%rip)
       0x0f, 0x1f, 0x40, 0x00, // nop
   };
   memcpy(buf, pltData, sizeof(pltData));
-  uint64_t gotPlt = in.gotPlt->getVA();
-  uint64_t plt = in.ibtPlt ? in.ibtPlt->getVA() : in.plt->getVA();
+  uint64_t gotPlt = c.gotPlt->getVA();
+  uint64_t plt = in.ibtPlt ? in.ibtPlt->getVA() : c.plt->getVA();
   write32le(buf + 2, gotPlt - plt + 2); // GOTPLT+8
   write32le(buf + 8, gotPlt - plt + 4); // GOTPLT+16
 }
 
-void X86_64::writePlt(uint8_t *buf, const Symbol &sym,
+void X86_64::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                       uint64_t pltEntryAddr) const {
   const uint8_t inst[] = {
       0xff, 0x25, 0, 0, 0, 0, // jmpq *got(%rip)
@@ -402,9 +403,9 @@ void X86_64::writePlt(uint8_t *buf, const Symbol &sym,
   };
   memcpy(buf, inst, sizeof(inst));
 
-  write32le(buf + 2, sym.getGotPltVA() - pltEntryAddr - 6);
-  write32le(buf + 7, sym.getPltIdx());
-  write32le(buf + 12, in.plt->getVA() - pltEntryAddr - 16);
+  write32le(buf + 2, sym.getGotPltVA(c) - pltEntryAddr - 6);
+  write32le(buf + 7, sym.getPltIdx(c));
+  write32le(buf + 12, c.plt->getVA() - pltEntryAddr - 16);
 }
 
 RelType X86_64::getDynRel(RelType type) const {
@@ -1012,10 +1013,12 @@ namespace {
 class IntelIBT : public X86_64 {
 public:
   IntelIBT();
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
-  void writeIBTPlt(uint8_t *buf, size_t numEntries) const override;
+  void writeIBTPlt(Compartment &c, uint8_t *buf,
+                   size_t numEntries) const override;
 
   static const unsigned IBTPltHeaderSize = 16;
 };
@@ -1023,13 +1026,14 @@ public:
 
 IntelIBT::IntelIBT() { pltHeaderSize = 0; }
 
-void IntelIBT::writeGotPlt(uint8_t *buf, const Symbol &s) const {
+void IntelIBT::writeGotPlt(Compartment &c, uint8_t *buf,
+                           const Symbol &s) const {
   uint64_t va =
-      in.ibtPlt->getVA() + IBTPltHeaderSize + s.getPltIdx() * pltEntrySize;
+      in.ibtPlt->getVA() + IBTPltHeaderSize + s.getPltIdx(c) * pltEntrySize;
   write64le(buf, va);
 }
 
-void IntelIBT::writePlt(uint8_t *buf, const Symbol &sym,
+void IntelIBT::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                         uint64_t pltEntryAddr) const {
   const uint8_t Inst[] = {
       0xf3, 0x0f, 0x1e, 0xfa,       // endbr64
@@ -1037,11 +1041,12 @@ void IntelIBT::writePlt(uint8_t *buf, const Symbol &sym,
       0x66, 0x0f, 0x1f, 0x44, 0, 0, // nop
   };
   memcpy(buf, Inst, sizeof(Inst));
-  write32le(buf + 6, sym.getGotPltVA() - pltEntryAddr - 10);
+  write32le(buf + 6, sym.getGotPltVA(c) - pltEntryAddr - 10);
 }
 
-void IntelIBT::writeIBTPlt(uint8_t *buf, size_t numEntries) const {
-  writePltHeader(buf);
+void IntelIBT::writeIBTPlt(Compartment &c, uint8_t *buf,
+                           size_t numEntries) const {
+  writePltHeader(c, buf);
   buf += IBTPltHeaderSize;
 
   const uint8_t inst[] = {
@@ -1072,18 +1077,20 @@ namespace {
 class Retpoline : public X86_64 {
 public:
   Retpoline();
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override;
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override;
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
 };
 
 class RetpolineZNow : public X86_64 {
 public:
   RetpolineZNow();
-  void writeGotPlt(uint8_t *buf, const Symbol &s) const override {}
-  void writePltHeader(uint8_t *buf) const override;
-  void writePlt(uint8_t *buf, const Symbol &sym,
+  void writeGotPlt(Compartment &c, uint8_t *buf,
+                   const Symbol &s) const override {}
+  void writePltHeader(Compartment &c, uint8_t *buf) const override;
+  void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
 };
 } // namespace
@@ -1094,11 +1101,12 @@ Retpoline::Retpoline() {
   ipltEntrySize = 32;
 }
 
-void Retpoline::writeGotPlt(uint8_t *buf, const Symbol &s) const {
-  write64le(buf, s.getPltVA() + 17);
+void Retpoline::writeGotPlt(Compartment &c, uint8_t *buf,
+                            const Symbol &s) const {
+  write64le(buf, s.getPltVA(c) + 17);
 }
 
-void Retpoline::writePltHeader(uint8_t *buf) const {
+void Retpoline::writePltHeader(Compartment &c, uint8_t *buf) const {
   const uint8_t insn[] = {
       0xff, 0x35, 0,    0,    0,    0,          // 0:    pushq GOTPLT+8(%rip)
       0x4c, 0x8b, 0x1d, 0,    0,    0,    0,    // 6:    mov GOTPLT+16(%rip), %r11
@@ -1114,13 +1122,13 @@ void Retpoline::writePltHeader(uint8_t *buf) const {
   };
   memcpy(buf, insn, sizeof(insn));
 
-  uint64_t gotPlt = in.gotPlt->getVA();
-  uint64_t plt = in.plt->getVA();
+  uint64_t gotPlt = c.gotPlt->getVA();
+  uint64_t plt = c.plt->getVA();
   write32le(buf + 2, gotPlt - plt - 6 + 8);
   write32le(buf + 9, gotPlt - plt - 13 + 16);
 }
 
-void Retpoline::writePlt(uint8_t *buf, const Symbol &sym,
+void Retpoline::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                          uint64_t pltEntryAddr) const {
   const uint8_t insn[] = {
       0x4c, 0x8b, 0x1d, 0, 0, 0, 0, // 0:  mov foo@GOTPLT(%rip), %r11
@@ -1132,12 +1140,12 @@ void Retpoline::writePlt(uint8_t *buf, const Symbol &sym,
   };
   memcpy(buf, insn, sizeof(insn));
 
-  uint64_t off = pltEntryAddr - in.plt->getVA();
+  uint64_t off = pltEntryAddr - c.plt->getVA();
 
-  write32le(buf + 3, sym.getGotPltVA() - pltEntryAddr - 7);
+  write32le(buf + 3, sym.getGotPltVA(c) - pltEntryAddr - 7);
   write32le(buf + 8, -off - 12 + 32);
   write32le(buf + 13, -off - 17 + 18);
-  write32le(buf + 18, sym.getPltIdx());
+  write32le(buf + 18, sym.getPltIdx(c));
   write32le(buf + 23, -off - 27);
 }
 
@@ -1147,7 +1155,7 @@ RetpolineZNow::RetpolineZNow() {
   ipltEntrySize = 16;
 }
 
-void RetpolineZNow::writePltHeader(uint8_t *buf) const {
+void RetpolineZNow::writePltHeader(Compartment &c, uint8_t *buf) const {
   const uint8_t insn[] = {
       0xe8, 0x0b, 0x00, 0x00, 0x00, // 0:    call next
       0xf3, 0x90,                   // 5:  loop: pause
@@ -1163,7 +1171,7 @@ void RetpolineZNow::writePltHeader(uint8_t *buf) const {
   memcpy(buf, insn, sizeof(insn));
 }
 
-void RetpolineZNow::writePlt(uint8_t *buf, const Symbol &sym,
+void RetpolineZNow::writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                              uint64_t pltEntryAddr) const {
   const uint8_t insn[] = {
       0x4c, 0x8b, 0x1d, 0,    0, 0, 0, // mov foo@GOTPLT(%rip), %r11
@@ -1172,8 +1180,8 @@ void RetpolineZNow::writePlt(uint8_t *buf, const Symbol &sym,
   };
   memcpy(buf, insn, sizeof(insn));
 
-  write32le(buf + 3, sym.getGotPltVA() - pltEntryAddr - 7);
-  write32le(buf + 8, in.plt->getVA() - pltEntryAddr - 12);
+  write32le(buf + 3, sym.getGotPltVA(c) - pltEntryAddr - 7);
+  write32le(buf + 8, c.plt->getVA() - pltEntryAddr - 12);
 }
 
 static TargetInfo *getTargetInfo() {

--- a/lld/ELF/CMakeLists.txt
+++ b/lld/ELF/CMakeLists.txt
@@ -38,6 +38,7 @@ add_lld_library(lldELF
   Arch/X86_64.cpp
   ARMErrataFix.cpp
   CallGraphSort.cpp
+  Compartments.cpp
   DWARF.cpp
   Driver.cpp
   DriverUtils.cpp

--- a/lld/ELF/Compartments.cpp
+++ b/lld/ELF/Compartments.cpp
@@ -380,8 +380,9 @@ static void checkDefaultCompartment() {
 template <class ELFT, class RelTy>
 static void scanRelocations(InputSectionBase *sec, ArrayRef<RelTy> rels,
                             SectionDepends &depends) {
+  const Compartment &c = sec->getCompartment();
   for (const auto &rel : rels) {
-    Symbol &sym = sec->getFile<ELFT>()->getRelocTargetSym(rel);
+    Symbol &sym = sec->getFile<ELFT>()->getRelocTargetSym(c, rel);
     if (sym.isUndefined())
       continue;
 
@@ -422,6 +423,26 @@ static void scanRelocations(InputSectionBase *sec, SectionDepends &depends) {
     scanRelocations<ELFT>(sec, rels.rels, depends);
   else
     scanRelocations<ELFT>(sec, rels.relas, depends);
+}
+
+static void duplicateSectionsForCompartments() {
+  SmallVector<InputSectionBase *, 0> newSections;
+  for (InputSectionBase *s : ctx.inputSections) {
+    if (!canCompartmentalize(s) || s->compartment != 0 ||
+        !MergeInputSection::classof(s) || firstExportedSymbol(s) != nullptr) {
+      continue;
+    }
+
+    MergeInputSection *ms = cast<MergeInputSection>(s);
+    for (Compartment &c : compartments) {
+      if (c.isDefault())
+        continue;
+      newSections.push_back(ms->clone(c));
+    }
+  }
+
+  ctx.inputSections.insert(ctx.inputSections.end(), newSections.begin(),
+                           newSections.end());
 }
 
 void assignSectionsToCompartments() {
@@ -514,7 +535,10 @@ void assignSectionsToCompartments() {
   if (!valid)
     exitLld(1);
 
-  // Third, build table of input section dependencies and add initial sets to
+  // Third, Duplicate SHF_MERGE sections not yet assigned to a compartment.
+  duplicateSectionsForCompartments();
+
+  // Fourth, build table of input section dependencies and add initial sets to
   // DSU used in fifth step.
   SectionDepends depends;
   SectionDSU dsu;
@@ -529,7 +553,7 @@ void assignSectionsToCompartments() {
     dsu.makeSet(s);
   }
 
-  // Fourth, for purecap CHERI, look for "hard" dependencies where an
+  // Fifth, for purecap CHERI, look for "hard" dependencies where an
   // input section is required to be contained within the PCC bounds
   // of another compartmentalized section.  These dependencies should
   // always be from .text sections against some other section.  This
@@ -630,7 +654,7 @@ void assignSectionsToCompartments() {
     }
   }
 
-  // Fifth, look for compartmentalizable sections not yet assigned to a
+  // Sixth, look for compartmentalizable sections not yet assigned to a
   // compartment that can be compartmentalized.  Start by using a disjoint set
   // union pattern to build sets of related input sections.  Note that edges
   // between sections that are already compartmentalized are ignored.  The goal

--- a/lld/ELF/Compartments.cpp
+++ b/lld/ELF/Compartments.cpp
@@ -1,0 +1,768 @@
+//===- Compartments.cpp ---------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains support for sub-object compartments.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Compartments.h"
+#include "Arch/Cheri.h"
+#include "Config.h"
+#include "InputFiles.h"
+#include "SyntheticSections.h"
+#include "llvm/Support/Errc.h"
+#include "llvm/Support/GlobPattern.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/Path.h"
+
+#include <list>
+#include <set>
+
+using namespace llvm;
+using namespace llvm::object;
+using namespace lld;
+using namespace lld::elf;
+
+// ELF relocations describe inter-section dependencies where the input
+// section S1 containing the relocation address depends on the input
+// section S2 that defines the target symbol.
+//
+// SectionDepends is a map of each S2 section that holds a logical
+// list of unique <S1, RelExpr> tuples that target S2.  This
+// list is actually stored as a map where each tuple is mapped to the
+// first Symbol targeted by such a tuple.  This permits using the
+// Symbol's name in diagnostic messages.
+typedef std::pair<InputSectionBase *, RelExpr> SectionKey;
+typedef std::unordered_map<SectionKey, Symbol &> SectionDeps;
+typedef std::map<InputSectionBase *, SectionDeps> SectionDepends;
+
+// CompartmentDeps is constructed by walking a single SectionDeps
+// collapsing entries from multiple <section, relocation, symbol>
+// tuples down to a single representative <section, symbol> pair from
+// each Compartment.
+typedef std::pair<const InputSectionBase *, const Symbol *> CompartmentValue;
+typedef std::map<Compartment *, CompartmentValue> CompartmentDeps;
+
+namespace std {
+template <> struct less<Compartment *> {
+  bool operator()(const Compartment *lhs, const Compartment *rhs) const {
+    if (lhs->isDefault() || rhs->isDefault())
+      return !rhs->isDefault();
+
+    return lhs->name.compare(rhs->name) < 0;
+  }
+};
+
+template <> struct less<InputSectionBase *> {
+  bool operator()(const InputSectionBase *lhs,
+                  const InputSectionBase *rhs) const {
+    if (lhs->file != nullptr || rhs->file != nullptr) {
+      if (lhs->file == nullptr)
+        return true;
+      if (rhs->file == nullptr)
+        return false;
+
+      int rval = lhs->file->getName().compare(rhs->file->getName());
+      if (rval < 0)
+        return true;
+      if (rval > 0)
+        return false;
+    }
+
+    return lhs->name.compare(rhs->name) < 0;
+  }
+};
+
+template <> struct hash<SectionKey> {
+  size_t operator()(SectionKey A) const {
+    size_t h1 = std::hash<InputSectionBase *>{}(A.first);
+    size_t h2 = std::hash<RelExpr>{}(A.second);
+    return h1 ^ (h2 << 1);
+  }
+};
+} // namespace std
+
+namespace lld {
+namespace elf {
+
+class CompartmentLookup {
+public:
+  bool addPattern(StringRef glob, Compartment &c) {
+    Expected<GlobPattern> GlobOrErr = GlobPattern::create(glob);
+    if (!GlobOrErr) {
+      error(toString(GlobOrErr.takeError()));
+      return false;
+    }
+    matches.emplace_back(std::make_pair(std::move(*GlobOrErr), &c));
+    return true;
+  }
+
+  Expected<Compartment &> findMatch(StringRef name) const {
+    Compartment *current = defaultCompart;
+
+    for (const auto &p : matches) {
+      if (!p.first.match(name))
+        continue;
+
+      if (current == p.second)
+        continue;
+      if (current != defaultCompart)
+        return make_error<StringError>("assigned to compartment " +
+                                           current->name + " and " +
+                                           p.second->name,
+                                       errc::invalid_argument);
+      current = p.second;
+    }
+    return *current;
+  }
+
+private:
+  std::vector<std::pair<GlobPattern, Compartment *>> matches;
+};
+
+// A disjoint set union of input sections is implemented by having a
+// std::unordered_map<> map input section pointers to a parent input section.  A
+// std::map<> maps tree root input sections to a list of all set members.
+typedef std::list<InputSectionBase *> SectionList;
+
+class SectionDSU {
+  typedef std::map<InputSectionBase *, SectionList> setMap;
+
+public:
+  class iterator {
+  public:
+    explicit iterator(setMap &sets, bool start) {
+      end = sets.end();
+      if (start) {
+        it = next(sets.begin());
+      } else {
+        it = end;
+      }
+    }
+
+    iterator &operator++() {
+      it = next(++it);
+      return *this;
+    }
+    iterator operator++(int) {
+      iterator retval = *this;
+      ++(*this);
+      return retval;
+    }
+    bool operator==(iterator other) const { return it == other.it; }
+    bool operator!=(iterator other) const { return it != other.it; }
+    SectionList &operator*() const { return it->second; }
+
+  private:
+    setMap::iterator next(setMap::iterator it) {
+      while (it != end && it->second.empty())
+        it++;
+      return it;
+    }
+
+    setMap::iterator it;
+    setMap::iterator end;
+  };
+
+  iterator begin() { return iterator(sets, true); }
+  iterator end() { return iterator(sets, false); }
+
+  void makeSet(InputSectionBase *s) {
+    parents.emplace(s, s);
+    sets.emplace(s, std::initializer_list<InputSectionBase *>({s}));
+  }
+
+  InputSectionBase *findSet(InputSectionBase *s) {
+    if (parents[s] == s)
+      return s;
+    return parents[s] = findSet(parents[s]);
+  }
+
+  void unionSets(InputSectionBase *a, InputSectionBase *b) {
+    a = findSet(a);
+    b = findSet(b);
+    if (a == b)
+      return;
+
+    if (std::less<InputSectionBase *>()(b, a))
+      std::swap(a, b);
+
+    SectionList &aList = sets[a];
+    SectionList &bList = sets[b];
+    aList.splice(aList.end(), bList);
+    parents[b] = a;
+  }
+
+private:
+  std::unordered_map<InputSectionBase *, InputSectionBase *> parents;
+  setMap sets;
+};
+
+static void addCompartment(StringRef name) {
+  compartments.emplace_back();
+  Compartment &newCompart = compartments.back();
+  newCompart.name = name;
+}
+
+static Compartment *findCompartment(StringRef name) {
+  if (name.empty())
+    return defaultCompart;
+  for (Compartment &compart : compartments) {
+    if (compart.name.compare(name) == 0)
+      return &compart;
+  }
+  return nullptr;
+}
+
+static bool fromJSON(const json::Value &E, CompartmentMembers &Out,
+                     json::Path P) {
+  llvm::json::ObjectMapper O(E, P);
+  return O && O.mapOptional("symbols", Out.symbols) &&
+         O.mapOptional("files", Out.files);
+}
+
+static bool fromJSON(const json::Value &E, CompartmentPolicy &Out,
+                     json::Path P) {
+  llvm::json::ObjectMapper O(E, P);
+  return O && O.map("compartments", Out.compartments);
+}
+
+void readCompartmentPolicy(MemoryBufferRef mb) {
+  Expected<CompartmentPolicy> policy =
+      json::parse<CompartmentPolicy>(mb.getBuffer());
+  if (!policy)
+    fatal(Twine("failed to parse compartmentalization policy \"") +
+          mb.getBufferIdentifier() + Twine("\": ") +
+          toString(policy.takeError()));
+
+  for (const auto &kv : policy->compartments) {
+    if (findCompartment(kv.first) != nullptr)
+      continue;
+    addCompartment(kv.first);
+  }
+
+  config->compartmentPolicies.emplace_back(std::move(*policy));
+}
+
+static std::string compartmentName(const Compartment &c) {
+  if (c.isDefault())
+    return "the default compartment";
+  else
+    return "compartment " + toString(c.name);
+}
+
+static std::string isecName(const InputSectionBase *s) {
+  return "input section " + toString(s->file->getName()) + ":" +
+         toString(s->name);
+}
+
+static std::string symbolName(const Symbol *sym) {
+  if (sym->getName().empty())
+    return "local symbol";
+  else
+    return "symbol " + toString(sym->getName());
+}
+
+static Compartment &
+compartmentForSection(const InputSectionBase *s,
+                      const CompartmentLookup &symbolLookup) {
+  if (s->file == nullptr)
+    return *defaultCompart;
+
+  InputFile *f = s->file;
+  Symbol *firstSym = nullptr;
+  Compartment *current = defaultCompart;
+  bool hasError = false;
+  std::vector<Symbol *> implicit_symbols;
+  for (Symbol *b : f->getSymbols()) {
+    if (Defined *d = dyn_cast<Defined>(b)) {
+      if (d->section != s)
+        continue;
+
+      if (b->getName().empty())
+        continue;
+
+      Expected<Compartment &> symbolC = symbolLookup.findMatch(b->getName());
+      if (!symbolC) {
+        error("symbol " + b->getName() + " " + toString(symbolC.takeError()));
+        hasError = true;
+        continue;
+      }
+
+      if (&*symbolC == current)
+        continue;
+
+      // Allow unspecified symbols to follow other rules for their containing
+      // section.
+      if (symbolC->isDefault()) {
+        implicit_symbols.emplace_back(d);
+        continue;
+      }
+
+      if (!current->isDefault()) {
+        error(isecName(s) + " assigned to " + compartmentName(*current) +
+              " by " + symbolName(firstSym) + " and " +
+              compartmentName(*symbolC) + " by " + symbolName(b));
+        hasError = true;
+      } else {
+        current = &*symbolC;
+        firstSym = b;
+      }
+    }
+  }
+  if (hasError)
+    exitLld(1);
+
+  // Finally, if a compartment was assigned by a subset of symbols, note any
+  // symbols that inherited this compartment.
+  if (config->verboseCompartmentalization && current != nullptr) {
+    for (Symbol *b : implicit_symbols) {
+      if (!b->includeInDynsym())
+        continue;
+      message("note: " + symbolName(b) + " implicitly assigned to " +
+              compartmentName(*current));
+    }
+  }
+
+  return *current;
+}
+
+// Returns true for sections that can be assigned to a compartment
+static bool canCompartmentalize(const InputSectionBase *s) {
+  return s->name.startswith(".text") || s->name.startswith(".rodata") ||
+         s->name.startswith(".data") || s->name.startswith(".bss");
+}
+
+// Returns a pointer to an exported symbol if a section contains exported
+// symbols.  This is not perfect as it is called before relocations are scanned.
+static Symbol *firstExportedSymbol(const InputSectionBase *s) {
+  InputFile *f = s->file;
+  for (Symbol *b : f->getSymbols()) {
+    if (Defined *d = dyn_cast<Defined>(b)) {
+      if (d->section != s)
+        continue;
+
+      if (!b->includeInDynsym())
+        continue;
+
+      return b;
+    }
+  }
+  return nullptr;
+}
+
+static void checkDefaultCompartment() {
+  bool valid = true;
+  if (config->noDefaultCompartment) {
+    for (InputSectionBase *s : ctx.inputSections) {
+      if (s->file == nullptr || (s->flags & ELF::SHF_ALLOC) == 0)
+        continue;
+
+      if (!canCompartmentalize(s))
+        continue;
+
+      if (s->compartment == 0) {
+        error(isecName(s) + " not assigned to a compartment");
+        valid = false;
+      }
+    }
+    if (!valid)
+      exitLld(1);
+  }
+}
+
+template <class ELFT, class RelTy>
+static InputSectionBase *relocationTargetSection(InputSectionBase *sec,
+                                                 const RelTy &rel) {
+  uint32_t symIndex = rel.getSymbol(config->isMips64EL);
+  Symbol &sym = sec->getFile<ELFT>()->getSymbol(symIndex);
+
+  if (sym.isUndefined())
+    return nullptr;
+
+  Defined *d = dyn_cast<Defined>(&sym);
+  if (d == nullptr)
+    return nullptr;
+
+  return static_cast<InputSectionBase *>(d->section);
+}
+
+template <class ELFT, class RelTy>
+static void scanRelocations(InputSectionBase *sec, ArrayRef<RelTy> rels,
+                            SectionDepends &depends) {
+  for (const auto &rel : rels) {
+    InputSectionBase *tsec = relocationTargetSection<ELFT>(sec, rel);
+
+    if (tsec == nullptr)
+      continue;
+
+    // Ignore self-dependencies.
+    if (tsec == sec)
+      continue;
+
+    uint64_t offset = rel.r_offset;
+    if (offset == uint64_t(-1))
+      continue;
+
+    RelType type = rel.getType(config->isMips64EL);
+    uint32_t symIndex = rel.getSymbol(config->isMips64EL);
+    Symbol &sym = sec->getFile<ELFT>()->getSymbol(symIndex);
+    const uint8_t *loc = sec->content().begin() + offset;
+    RelExpr expr = target->getRelExpr(type, sym, loc);
+    if (expr == R_NONE)
+      continue;
+
+    SectionDeps &sdeps = depends[tsec];
+    SectionKey key(sec, expr);
+    if (sdeps.count(key) == 0) {
+      sdeps.emplace(key, sym);
+    }
+  }
+}
+
+template <class ELFT>
+static void scanRelocations(InputSectionBase *sec, SectionDepends &depends) {
+  const RelsOrRelas<ELFT> rels = sec->template relsOrRelas<ELFT>();
+  if (rels.areRelocsRel())
+    scanRelocations<ELFT>(sec, rels.rels, depends);
+  else
+    scanRelocations<ELFT>(sec, rels.relas, depends);
+}
+
+void assignSectionsToCompartments() {
+  if (compartments.size() == 1) {
+    checkDefaultCompartment();
+    return;
+  }
+
+  for (Compartment &c : compartments) {
+    if (c.isDefault())
+      continue;
+    c.suffix = "." + c.name.str();
+  }
+
+  bool valid = true;
+  CompartmentLookup fileLookup;
+  CompartmentLookup symbolLookup;
+  for (const auto &policy : config->compartmentPolicies) {
+    for (const auto &kv : policy.compartments) {
+      Compartment *c = findCompartment(kv.first);
+      for (const auto &glob : kv.second.files) {
+        valid &= fileLookup.addPattern(glob, *c);
+      }
+      for (const auto &glob : kv.second.symbols) {
+        valid &= symbolLookup.addPattern(glob, *c);
+      }
+    }
+  }
+  if (!valid)
+    exitLld(1);
+
+  // First, bind input object files to compartments using file patterns.  Note
+  // that there is no global list of input files, so have to walk input sections
+  // instead.
+  InputFile *lastFile = nullptr;
+  for (InputSectionBase *s : ctx.inputSections) {
+    if (s->file == nullptr || s->file == lastFile)
+      continue;
+    lastFile = s->file;
+    assert(s->file->compartment == 0);
+
+    StringRef path = s->file->getName();
+    Expected<Compartment &> c = fileLookup.findMatch(path);
+    if (!c) {
+      error("input file " + path + " " + toString(c.takeError()));
+      valid = false;
+      continue;
+    }
+
+    // If the path is not a basename, try to match on the basename.
+    if (c->isDefault() && llvm::sys::path::has_parent_path(path)) {
+      c = fileLookup.findMatch(llvm::sys::path::filename(path));
+      if (!c) {
+        error("input file " + path + " " + toString(c.takeError()));
+        valid = false;
+        continue;
+      }
+    }
+
+    if (c->isDefault())
+      continue;
+
+    s->file->compartment = c->getNumber();
+    if (config->verboseCompartmentalization)
+      message("info: input file " + s->file->getName() + " matched to " +
+              compartmentName(*c));
+  }
+
+  // Second, make a first pass assigning input sections to compartments based on
+  // symbol patterns.  This also reports errors for conflicting assignments.
+  for (InputSectionBase *s : ctx.inputSections) {
+    if (!canCompartmentalize(s)) {
+      continue;
+    }
+
+    Compartment *c = &compartmentForSection(s, symbolLookup);
+    if (s->file != nullptr && s->file->compartment != 0) {
+      Compartment &sc = compartments[s->file->compartment];
+      if (c->isDefault())
+        c = &sc;
+      else if (&sc != c) {
+        error("input file assigned to " + compartmentName(sc) +
+              " but symbols in section " + s->name + " assigned to " +
+              compartmentName(*c));
+        valid = false;
+        continue;
+      }
+    }
+    if (c == nullptr)
+      continue;
+
+    if (config->verboseCompartmentalization)
+      message("info: " + isecName(s) + " assigned to " + compartmentName(*c));
+    s->compartment = c->getNumber();
+  }
+  if (!valid)
+    exitLld(1);
+
+  // Third, build table of input section dependencies and add initial sets to
+  // DSU used in fifth step.
+  SectionDepends depends;
+  SectionDSU dsu;
+  for (InputSectionBase *s : ctx.inputSections) {
+    if (s->file == nullptr || (s->flags & ELF::SHF_ALLOC) == 0)
+      continue;
+
+    if (s->name == ".eh_frame")
+      continue;
+
+    invokeELFT(scanRelocations, s, depends);
+    dsu.makeSet(s);
+  }
+
+  // Fourth, for purecap CHERI, look for "hard" dependencies where an
+  // input section is required to be contained within the PCC bounds
+  // of another compartmentalized section.  These dependencies should
+  // always be from .text sections against some other section.  This
+  // repeats until no new sections are assigned.
+  if (config->isCheriAbi) {
+    for (;;) {
+      bool assigned = false;
+      for (const auto &kv : depends) {
+        InputSectionBase *s2 = kv.first;
+        const SectionDeps &sdeps = kv.second;
+
+        CompartmentDeps cdeps;
+        for (const auto &skv : sdeps) {
+          RelExpr expr = skv.first.second;
+          switch (expr) {
+          case R_PC:
+          case R_AARCH64_PAGE_PC:
+            break;
+          default:
+            continue;
+          }
+
+          const InputSectionBase *s1 = skv.first.first;
+          Compartment *c = &s1->getCompartment();
+          if (cdeps.count(c) == 0)
+            cdeps[c] = std::make_pair(s1, &skv.second);
+        }
+        if (cdeps.size() == 0)
+          continue;
+
+        if (cdeps.size() > 1) {
+          std::string clist;
+          for (const auto &cdep : cdeps) {
+            Compartment &c = *cdep.first;
+            const auto pair = cdep.second;
+            const InputSectionBase *s1 = pair.first;
+            const Symbol *sym = pair.second;
+
+            clist += "\n\t" + toString(compartmentName(c)) +
+                     " directly accesses " + toString(symbolName(sym)) +
+                     " from " + toString(isecName(s1));
+          }
+          error(isecName(s2) + " required by multiple compartments:" + clist);
+          valid = false;
+          continue;
+        }
+
+        Compartment &c = *cdeps.begin()->first;
+        if (c.getNumber() == s2->compartment)
+          continue;
+
+        const auto pair = cdeps.begin()->second;
+        const InputSectionBase *s1 = pair.first;
+        const Symbol *sym = pair.second;
+
+        if (s2->compartment != 0) {
+          error(symbolName(sym) + " assigned to " +
+                compartmentName(s2->getCompartment()) +
+                " is directly accessed by " + compartmentName(c) + " in " +
+                isecName(s1));
+          valid = false;
+          continue;
+        }
+
+        if (!canCompartmentalize(s2)) {
+          error(isecName(s2) + " containing " + symbolName(sym) +
+                " directly accessed by " + compartmentName(c) + " in " +
+                isecName(s1) + " cannot be compartmentalized");
+          valid = false;
+          continue;
+        }
+
+        Symbol *exported = firstExportedSymbol(s2);
+        if (exported != nullptr) {
+          error(isecName(s2) + " containing " + symbolName(sym) +
+                " directly accessed by " + compartmentName(c) + " in " +
+                isecName(s1) + " cannot be assigned due to exported " +
+                symbolName(exported));
+          valid = false;
+          continue;
+        }
+
+        // Report multiple errors before exiting
+        if (!valid)
+          continue;
+
+        if (config->verboseCompartmentalization)
+          message("info: " + isecName(s2) + " assigned to implied " +
+                  compartmentName(c) + " due to direct access of " +
+                  symbolName(sym) + " in " + isecName(s1));
+        s2->compartment = c.getNumber();
+        assigned = true;
+      }
+      if (!valid)
+        exitLld(1);
+      if (!assigned)
+        break;
+    }
+  }
+
+  // Fifth, look for compartmentalizable sections not yet assigned to a
+  // compartment that can be compartmentalized.  Start by using a disjoint set
+  // union pattern to build sets of related input sections.  Note that edges
+  // between sections that are already compartmentalized are ignored.  The goal
+  // is to find sets of sections in the default compartment that are only used
+  // by a single compartment.
+  for (const auto &kv : depends) {
+    InputSectionBase *s2 = kv.first;
+    const SectionDeps &sdeps = kv.second;
+    for (const auto &skv : sdeps) {
+      InputSectionBase *s1 = skv.first.first;
+
+      if (s1->compartment != 0 && s2->compartment != 0)
+        continue;
+      dsu.unionSets(s2, s1);
+    }
+  }
+
+  for (SectionList &list : dsu) {
+    // Ignore singleton sets.
+    if (list.size() == 1) {
+      if (config->verboseCompartmentalization) {
+        InputSectionBase *s = list.front();
+        if (s->compartment == 0 && canCompartmentalize(s)) {
+          message("info: potential compartment:");
+          message("\t" + isecName(s));
+        }
+      }
+      continue;
+    }
+
+    if (config->verboseCompartmentalization) {
+      std::set<InputSectionBase *> set;
+      for (InputSectionBase *s : list)
+        set.insert(s);
+      list.clear();
+      for (InputSectionBase *s : set)
+        list.push_back(s);
+    }
+
+    // More than one compartment?
+    Compartment *c = defaultCompart;
+    bool multiple = false;
+    bool anyDefault = false;
+    for (InputSectionBase *s : list) {
+      if (!canCompartmentalize(s))
+        continue;
+      if (s->compartment == 0) {
+        anyDefault = true;
+        continue;
+      }
+      if (c->isDefault()) {
+        c = &s->getCompartment();
+        continue;
+      }
+      if (c->getNumber() == s->compartment)
+        continue;
+      multiple = true;
+      break;
+    }
+
+    if (multiple) {
+      if (config->verboseCompartmentalization) {
+        message("info: disjoint set spans multiple compartments:");
+        for (InputSectionBase *s : list)
+          if (canCompartmentalize(s))
+            message("\t" + isecName(s) + " from " +
+                    compartmentName(s->getCompartment()));
+      }
+      continue;
+    }
+
+    // Nothing to do if the sole compartment is the default compartment or all
+    // of the input sections are already assigned.
+    if (!anyDefault)
+      continue;
+    if (c == nullptr) {
+      if (config->verboseCompartmentalization) {
+        message("info: potential compartment:");
+        for (InputSectionBase *s : list)
+          if (canCompartmentalize(s))
+            message("\t" + isecName(s));
+      }
+      continue;
+    }
+
+    // Don't assign anything if any of the input sections in the default
+    // compartment contain exported symbols.
+    bool exportedSym = false;
+    for (InputSectionBase *s : list) {
+      if (s->compartment == c->getNumber() || !canCompartmentalize(s))
+        continue;
+
+      Symbol *b = firstExportedSymbol(s);
+      if (b != nullptr) {
+        message("info: " + isecName(s) + " not assigned to implied " +
+                compartmentName(*c) + " due to exported " + symbolName(b));
+        exportedSym = true;
+      }
+    }
+    if (exportedSym)
+      continue;
+
+    if (config->verboseCompartmentalization)
+      message("info: assigning disjoint set to " + compartmentName(*c) + ":");
+    for (InputSectionBase *s : list) {
+      if (s->compartment == c->getNumber() || !canCompartmentalize(s))
+        continue;
+
+      s->compartment = c->getNumber();
+      if (config->verboseCompartmentalization)
+        message("\t" + isecName(s));
+    }
+  }
+
+  checkDefaultCompartment();
+}
+
+} // namespace elf
+} // namespace lld

--- a/lld/ELF/Compartments.cpp
+++ b/lld/ELF/Compartments.cpp
@@ -207,6 +207,7 @@ static void addCompartment(StringRef name) {
   compartments.emplace_back();
   Compartment &newCompart = compartments.back();
   newCompart.name = name;
+  newCompart.suffix = "." + name.str();
 }
 
 static Compartment *findCompartment(StringRef name) {
@@ -377,27 +378,18 @@ static void checkDefaultCompartment() {
 }
 
 template <class ELFT, class RelTy>
-static InputSectionBase *relocationTargetSection(InputSectionBase *sec,
-                                                 const RelTy &rel) {
-  uint32_t symIndex = rel.getSymbol(config->isMips64EL);
-  Symbol &sym = sec->getFile<ELFT>()->getSymbol(symIndex);
-
-  if (sym.isUndefined())
-    return nullptr;
-
-  Defined *d = dyn_cast<Defined>(&sym);
-  if (d == nullptr)
-    return nullptr;
-
-  return static_cast<InputSectionBase *>(d->section);
-}
-
-template <class ELFT, class RelTy>
 static void scanRelocations(InputSectionBase *sec, ArrayRef<RelTy> rels,
                             SectionDepends &depends) {
   for (const auto &rel : rels) {
-    InputSectionBase *tsec = relocationTargetSection<ELFT>(sec, rel);
+    Symbol &sym = sec->getFile<ELFT>()->getRelocTargetSym(rel);
+    if (sym.isUndefined())
+      continue;
 
+    Defined *d = dyn_cast<Defined>(&sym);
+    if (d == nullptr)
+      continue;
+
+    InputSectionBase *tsec = static_cast<InputSectionBase *>(d->section);
     if (tsec == nullptr)
       continue;
 
@@ -410,8 +402,6 @@ static void scanRelocations(InputSectionBase *sec, ArrayRef<RelTy> rels,
       continue;
 
     RelType type = rel.getType(config->isMips64EL);
-    uint32_t symIndex = rel.getSymbol(config->isMips64EL);
-    Symbol &sym = sec->getFile<ELFT>()->getSymbol(symIndex);
     const uint8_t *loc = sec->content().begin() + offset;
     RelExpr expr = target->getRelExpr(type, sym, loc);
     if (expr == R_NONE)
@@ -438,12 +428,6 @@ void assignSectionsToCompartments() {
   if (compartments.size() == 1) {
     checkDefaultCompartment();
     return;
-  }
-
-  for (Compartment &c : compartments) {
-    if (c.isDefault())
-      continue;
-    c.suffix = "." + c.name.str();
   }
 
   bool valid = true;

--- a/lld/ELF/Compartments.cpp
+++ b/lld/ELF/Compartments.cpp
@@ -479,29 +479,48 @@ void assignSectionsToCompartments() {
     assert(s->file->compartment == 0);
 
     StringRef path = s->file->getName();
-    Expected<Compartment &> c = fileLookup.findMatch(path);
-    if (!c) {
-      error("input file " + path + " " + toString(c.takeError()));
-      valid = false;
-      continue;
+    StringRef scope = s->file->archiveName;
+    Twine scopedPath = scope.empty() ? path : scope + ":" + path;
+    Expected<Compartment &> c = *defaultCompart;
+    handleAllErrors(c.takeError());
+    auto tryMatch = [&](StringRef s) -> bool {
+      llvm::errs() << "tryMatch: " << s << "\n";
+      c = fileLookup.findMatch(s);
+      if (!c) {
+        error("input file " + scopedPath + " " + toString(c.takeError()));
+        valid = false;
+        return false;
+      }
+      return true;
+    };
+
+    // First, prioritise explicitly-scoped matches.
+    if (!scope.empty()) {
+      if (!tryMatch(scopedPath.str()))
+        continue;
+
+      // If the archive path is not a basename, try to match with a scope of
+      // just the basename.
+      if (c->isDefault() && llvm::sys::path::has_parent_path(scope) &&
+          !tryMatch((llvm::sys::path::filename(scope) + ":" + path).str()))
+        continue;
     }
 
+    // Next, prioritise matches with a full path.
+    if (c->isDefault() && !tryMatch(path))
+      continue;
+
     // If the path is not a basename, try to match on the basename.
-    if (c->isDefault() && llvm::sys::path::has_parent_path(path)) {
-      c = fileLookup.findMatch(llvm::sys::path::filename(path));
-      if (!c) {
-        error("input file " + path + " " + toString(c.takeError()));
-        valid = false;
-        continue;
-      }
-    }
+    if (c->isDefault() && llvm::sys::path::has_parent_path(path) &&
+        !tryMatch(llvm::sys::path::filename(path)))
+      continue;
 
     if (c->isDefault())
       continue;
 
     s->file->compartment = c->getNumber();
     if (config->verboseCompartmentalization)
-      message("info: input file " + s->file->getName() + " matched to " +
+      message("info: input file " + scopedPath + " matched to " +
               compartmentName(*c));
   }
 

--- a/lld/ELF/Compartments.h
+++ b/lld/ELF/Compartments.h
@@ -1,0 +1,27 @@
+//===- Compartments.h -------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLD_ELF_COMPARTMENTS_H
+#define LLD_ELF_COMPARTMENTS_H
+
+#include "lld/Common/LLVM.h"
+#include "llvm/Support/MemoryBufferRef.h"
+
+namespace lld {
+namespace elf {
+
+struct Compartment;
+
+void readCompartmentPolicy(MemoryBufferRef mb);
+
+void assignSectionsToCompartments();
+
+} // namespace elf
+} // namespace lld
+
+#endif

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -28,6 +28,7 @@
 #include "llvm/Support/GlobPattern.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include <atomic>
+#include <map>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -43,6 +44,7 @@ class InputSectionBase;
 class EhInputSection;
 class Symbol;
 class BitcodeCompiler;
+struct Compartment;
 
 enum ELFKind : uint8_t {
   ELFNoneKind,
@@ -141,6 +143,15 @@ private:
 
 public:
   SmallVector<std::pair<StringRef, unsigned>, 0> archiveFiles;
+};
+
+struct CompartmentMembers {
+  std::vector<std::string> symbols;
+  std::vector<std::string> files;
+};
+
+struct CompartmentPolicy {
+  std::map<std::string, CompartmentMembers> compartments;
 };
 
 // This struct contains the global configuration for the linker.
@@ -255,6 +266,7 @@ struct Config {
   bool mipsN32Abi = false;
   bool mmapOutputFile;
   bool nmagic;
+  bool noDefaultCompartment = false;
   bool noDynamicLinker = false;
   bool noinhibitExec;
   bool nostdlib;
@@ -447,6 +459,9 @@ struct Config {
   // If an input file matches a wildcard pattern, remap it to the value.
   llvm::SmallVector<std::pair<llvm::GlobPattern, llvm::StringRef>, 0>
       remapInputsWildcards;
+
+  std::vector<CompartmentPolicy> compartmentPolicies;
+  bool verboseCompartmentalization = false;
 };
 struct ConfigWrapper {
   Config c;

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -501,6 +501,8 @@ struct Ctx {
                  std::pair<const InputFile *, const InputFile *>>
       backwardReferences;
   llvm::SmallSet<llvm::StringRef, 0> auxiliaryFiles;
+  // Per-compartment symbols.
+  SmallVector<Symbol *, 0> compartSymbols;
   // True if SHT_LLVM_SYMPART is used.
   std::atomic<bool> hasSympart{false};
   // True if there are TLS IE relocations. Set DF_STATIC_TLS if -shared.

--- a/lld/ELF/DWARF.cpp
+++ b/lld/ELF/DWARF.cpp
@@ -16,6 +16,7 @@
 #include "DWARF.h"
 #include "InputSection.h"
 #include "Symbols.h"
+#include "SyntheticSections.h"
 #include "lld/Common/Memory.h"
 #include "llvm/DebugInfo/DWARF/DWARFDebugPubTable.h"
 #include "llvm/Object/ELFObjectFile.h"
@@ -119,7 +120,7 @@ LLDDwarfObj<ELFT>::findAux(const InputSectionBase &sec, uint64_t pos,
   // shall still resolve it. This is important for --gdb-index: the end address
   // offset of an entry in .debug_ranges is relocated. If it is not resolved,
   // its zero value will terminate the decoding of .debug_ranges prematurely.
-  Symbol &s = file->getRelocTargetSym(rel);
+  Symbol &s = file->getRelocTargetSym(sec.getCompartment(), rel);
   uint64_t val = 0;
   if (auto *dr = dyn_cast<Defined>(&s))
     val = dr->value;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -24,6 +24,7 @@
 
 #include "Driver.h"
 #include "Arch/Cheri.h"
+#include "Compartments.h"
 #include "Config.h"
 #include "ICF.h"
 #include "InputFiles.h"
@@ -134,6 +135,8 @@ bool link(ArrayRef<const char *> args, llvm::raw_ostream &stdoutOS,
     tar = nullptr;
     in.reset();
 
+    compartments.clear();
+    compartments.emplace_back();
     partitions.clear();
     partitions.emplace_back();
 
@@ -151,6 +154,8 @@ bool link(ArrayRef<const char *> args, llvm::raw_ostream &stdoutOS,
 
   symAux.emplace_back();
 
+  compartments.clear();
+  compartments.emplace_back();
   partitions.clear();
   partitions.emplace_back();
 
@@ -1279,6 +1284,7 @@ static void readConfigs(opt::InputArgList &args) {
   config->mmapOutputFile =
       args.hasFlag(OPT_mmap_output_file, OPT_no_mmap_output_file, true);
   config->nmagic = args.hasFlag(OPT_nmagic, OPT_no_nmagic, false);
+  config->noDefaultCompartment = args.hasArg(OPT_no_default_compartment);
   config->noinhibitExec = args.hasArg(OPT_noinhibit_exec);
   config->nostdlib = args.hasArg(OPT_nostdlib);
   config->oFormatBinary = isOutputFormatBinary(args);
@@ -1387,6 +1393,7 @@ static void readConfigs(opt::InputArgList &args) {
   config->useAndroidRelrTags = args.hasFlag(
       OPT_use_android_relr_tags, OPT_no_use_android_relr_tags, false);
   config->verboseCapRelocs = args.hasArg(OPT_verbose_cap_relocs);
+  config->verboseCompartmentalization = args.hasArg(OPT_verbose_c18n);
   config->warnBackrefs =
       args.hasFlag(OPT_warn_backrefs, OPT_no_warn_backrefs, false);
   config->warnCommon = args.hasFlag(OPT_warn_common, OPT_no_warn_common, false);
@@ -1691,6 +1698,19 @@ static void readConfigs(opt::InputArgList &args) {
     } else {
       error(Twine("cannot find version script ") + arg->getValue());
     }
+
+  for (auto *arg : args.filtered(OPT_compartment_policy))
+    if (std::optional<MemoryBufferRef> buffer = readFile(arg->getValue())) {
+      readCompartmentPolicy(*buffer);
+    } else {
+      error(Twine("cannot find compartmentalization policy ") +
+            arg->getValue());
+    }
+
+  // Impose a limit of 254 compartments.  This limit comes from the amount
+  // of space devoted to the compartment number in RankFlags.
+  if (compartments.size() > 254)
+    fatal("may not have more than 254 compartments");
 }
 
 // Some Config members do not directly correspond to any particular
@@ -2961,6 +2981,9 @@ void LinkerDriver::link(opt::InputArgList &args) {
   // partition.
   mainPart = &partitions[0];
 
+  // Similarly for the default compartment.
+  defaultCompart = &compartments[0];
+
   // Read .note.gnu.property sections from input object files which
   // contain a hint to tweak linker's and loader's behaviors.
   config->andFeatures = getAndFeatures();
@@ -3007,6 +3030,9 @@ void LinkerDriver::link(opt::InputArgList &args) {
   // Make copies of any input sections that need to be copied into each
   // partition.
   copySectionsIntoPartitions();
+
+  // Assign input sections to compartments.
+  assignSectionsToCompartments();
 
   // Create synthesized sections such as .got and .plt. This is called before
   // processSectionCommands() so that they can be placed by SECTIONS commands.

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -2331,11 +2331,12 @@ template <typename ELFT>
 static void readSymbolPartitionSection(InputSectionBase *s) {
   // Read the relocation that refers to the partition's entry point symbol.
   Symbol *sym;
+  const Compartment &c = s->getCompartment();
   const RelsOrRelas<ELFT> rels = s->template relsOrRelas<ELFT>();
   if (rels.areRelocsRel())
-    sym = &s->getFile<ELFT>()->getRelocTargetSym(rels.rels[0]);
+    sym = &s->getFile<ELFT>()->getRelocTargetSym(c, rels.rels[0]);
   else
-    sym = &s->getFile<ELFT>()->getRelocTargetSym(rels.relas[0]);
+    sym = &s->getFile<ELFT>()->getRelocTargetSym(c, rels.relas[0]);
   if (!isa<Defined>(sym) || !sym->includeInDynsym())
     return;
 
@@ -3020,6 +3021,9 @@ void LinkerDriver::link(opt::InputArgList &args) {
   if (!config->relocatable)
     ctx.inputSections.push_back(createCommentSection());
 
+  // Assign input sections to compartments.
+  assignSectionsToCompartments();
+
   // Split SHF_MERGE and .eh_frame sections into pieces in preparation for garbage collection.
   invokeELFT(splitSections,);
 
@@ -3030,9 +3034,6 @@ void LinkerDriver::link(opt::InputArgList &args) {
   // Make copies of any input sections that need to be copied into each
   // partition.
   copySectionsIntoPartitions();
-
-  // Assign input sections to compartments.
-  assignSectionsToCompartments();
 
   // Create synthesized sections such as .got and .plt. This is called before
   // processSectionCommands() so that they can be placed by SECTIONS commands.

--- a/lld/ELF/ICF.cpp
+++ b/lld/ELF/ICF.cpp
@@ -239,6 +239,8 @@ bool ICF<ELFT>::constantEq(const InputSection *secA, ArrayRef<RelTy> ra,
                            const InputSection *secB, ArrayRef<RelTy> rb) {
   if (ra.size() != rb.size())
     return false;
+  const Compartment &ca = secA->getCompartment();
+  const Compartment &cb = secB->getCompartment();
   for (size_t i = 0; i < ra.size(); ++i) {
     if (ra[i].r_offset != rb[i].r_offset ||
         ra[i].getType(config->isMips64EL) != rb[i].getType(config->isMips64EL))
@@ -247,8 +249,8 @@ bool ICF<ELFT>::constantEq(const InputSection *secA, ArrayRef<RelTy> ra,
     uint64_t addA = getAddend<ELFT>(ra[i]);
     uint64_t addB = getAddend<ELFT>(rb[i]);
 
-    Symbol &sa = secA->template getFile<ELFT>()->getRelocTargetSym(ra[i]);
-    Symbol &sb = secB->template getFile<ELFT>()->getRelocTargetSym(rb[i]);
+    Symbol &sa = secA->template getFile<ELFT>()->getRelocTargetSym(ca, ra[i]);
+    Symbol &sb = secB->template getFile<ELFT>()->getRelocTargetSym(cb, rb[i]);
     if (&sa == &sb) {
       if (addA == addB)
         continue;
@@ -336,10 +338,12 @@ bool ICF<ELFT>::variableEq(const InputSection *secA, ArrayRef<RelTy> ra,
                            const InputSection *secB, ArrayRef<RelTy> rb) {
   assert(ra.size() == rb.size());
 
+  const Compartment &ca = secA->getCompartment();
+  const Compartment &cb = secB->getCompartment();
   for (size_t i = 0; i < ra.size(); ++i) {
     // The two sections must be identical.
-    Symbol &sa = secA->template getFile<ELFT>()->getRelocTargetSym(ra[i]);
-    Symbol &sb = secB->template getFile<ELFT>()->getRelocTargetSym(rb[i]);
+    Symbol &sa = secA->template getFile<ELFT>()->getRelocTargetSym(ca, ra[i]);
+    Symbol &sb = secB->template getFile<ELFT>()->getRelocTargetSym(cb, rb[i]);
     if (&sa == &sb)
       continue;
 
@@ -441,8 +445,9 @@ template <class ELFT, class RelTy>
 static void combineRelocHashes(unsigned cnt, InputSection *isec,
                                ArrayRef<RelTy> rels) {
   uint32_t hash = isec->eqClass[cnt % 2];
+  const Compartment &c = isec->getCompartment();
   for (RelTy rel : rels) {
-    Symbol &s = isec->template getFile<ELFT>()->getRelocTargetSym(rel);
+    Symbol &s = isec->template getFile<ELFT>()->getRelocTargetSym(c, rel);
     if (auto *d = dyn_cast<Defined>(&s))
       if (auto *relSec = dyn_cast_or_null<InputSection>(d->section))
         hash += relSec->eqClass[cnt % 2];

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -955,6 +955,22 @@ template <class ELFT> static uint32_t readAndFeatures(const InputSection &sec) {
 }
 
 template <class ELFT>
+const Compartment &
+ObjFile<ELFT>::getRelocTargetCompartment(InputSectionBase *isec) {
+  assert(isec->type == SHT_REL || isec->type == SHT_RELA);
+
+  uint32_t idx = isec->info;
+  assert(idx < this->sections.size());
+
+  InputSectionBase *target = this->sections[idx];
+
+  if (target == &InputSection::discarded || target == nullptr)
+    return *defaultCompart;
+
+  return target->getCompartment();
+}
+
+template <class ELFT>
 InputSectionBase *ObjFile<ELFT>::getRelocTarget(uint32_t idx,
                                                 const Elf_Shdr &sec,
                                                 uint32_t info) {

--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -152,6 +152,9 @@ public:
   // R_PPC64_TLSLD. Disable TLS relaxation to avoid bad code generation.
   bool ppc64DisableTLSRelax = false;
 
+  // Compartment containing this file.
+  uint8_t compartment = 0;
+
 protected:
   InputFile(Kind k, MemoryBufferRef m);
 

--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -254,10 +254,13 @@ public:
 
   uint32_t getSectionIndex(const Elf_Sym &sym) const;
 
-  template <typename RelT> Symbol &getRelocTargetSym(const RelT &rel) const {
+  template <typename RelT>
+  Symbol &getRelocTargetSym(const Compartment &c, const RelT &rel) const {
     uint32_t symIndex = rel.getSymbol(config->isMips64EL);
-    return getSymbol(symIndex);
+    return getCompartmentSymbol(c, getSymbol(symIndex));
   }
+
+  const Compartment &getRelocTargetCompartment(InputSectionBase *isec);
 
   std::optional<llvm::DILineInfo> getDILineInfo(const InputSectionBase *, uint64_t);
   std::optional<std::pair<std::string, unsigned>>

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -374,12 +374,13 @@ template <class ELFT, class RelTy>
 void InputSection::copyRelocations(uint8_t *buf, ArrayRef<RelTy> rels) {
   const TargetInfo &target = *elf::target;
   InputSectionBase *sec = getRelocatedSection();
+  const Compartment &c = getCompartment();
   (void)sec->contentMaybeDecompress(); // uncompress if needed
 
   for (const RelTy &rel : rels) {
     RelType type = rel.getType(config->isMips64EL);
     const ObjFile<ELFT> *file = getFile<ELFT>();
-    Symbol &sym = file->getRelocTargetSym(rel);
+    Symbol &sym = file->getRelocTargetSym(c, rel);
 
     auto *p = reinterpret_cast<typename ELFT::Rela *>(buf);
     buf += sizeof(RelTy);
@@ -970,6 +971,7 @@ void InputSection::relocateNonAlloc(uint8_t *buf, ArrayRef<RelTy> rels) {
       break;
     }
 
+  const Compartment &c = getCompartment();
   for (const RelTy &rel : rels) {
     RelType type = rel.getType(config->isMips64EL);
 
@@ -986,7 +988,7 @@ void InputSection::relocateNonAlloc(uint8_t *buf, ArrayRef<RelTy> rels) {
     if (!RelTy::IsRela)
       addend += target.getImplicitAddend(bufLoc, type);
 
-    Symbol &sym = getFile<ELFT>()->getRelocTargetSym(rel);
+    Symbol &sym = getFile<ELFT>()->getRelocTargetSym(c, rel);
     RelExpr expr = target.getRelExpr(type, sym, bufLoc);
     if (expr == R_NONE)
       continue;
@@ -1406,6 +1408,62 @@ MergeInputSection::MergeInputSection(uint64_t flags, uint32_t type,
     : InputSectionBase(nullptr, flags, type, entsize, /*Link*/ 0, /*Info*/ 0,
                        /*Alignment*/ entsize, data, name, SectionBase::Merge) {}
 
+MergeInputSection::MergeInputSection(const Compartment &c,
+                                     const MergeInputSection &other)
+    : InputSectionBase(other) {
+  name = saver().save(other.name + c.suffix);
+  compartment = c.getNumber();
+}
+
+MergeInputSection *MergeInputSection::clone(const Compartment &c) {
+  MergeInputSection *copy = make<MergeInputSection>(c, *this);
+  if (file)
+    copy->cloneSymbols(this);
+
+  if (clones.size() == 0)
+    clones.resize(compartments.size());
+  assert(clones[copy->compartment] == nullptr);
+  clones[copy->compartment] = copy;
+  return copy;
+}
+
+void MergeInputSection::cloneSymbols(const MergeInputSection *other) {
+  const Compartment &c = getCompartment();
+  assert(!c.isDefault());
+  for (Symbol *b : file->getSymbols()) {
+    if (Defined *d = dyn_cast<Defined>(b)) {
+      if (d->section != other)
+        continue;
+
+      StringRef newName;
+      if (!d->getName().empty())
+        newName = saver().save(d->getName() + c.suffix);
+
+      Defined *newSym =
+          makeDefined(file, newName, (uint8_t)d->binding, d->stOther,
+                      (uint8_t)d->type, d->value, d->getSize(), this);
+      ctx.compartSymbols.push_back(newSym);
+      symMap.emplace(b, newSym);
+    }
+  }
+}
+
+Symbol &MergeInputSection::getCompartmentSymbol(const Compartment &c,
+                                                Symbol &other) {
+  if (c.isDefault() || clones.size() == 0)
+    return other;
+
+  Defined *d = dyn_cast<Defined>(&other);
+  assert(d != nullptr);
+  assert(d->section == this);
+
+  assert(c.getNumber() < clones.size() && clones[c.getNumber()] != nullptr);
+  MergeInputSection *ms = clones[c.getNumber()];
+
+  assert(ms->symMap.count(&other) != 0);
+  return *ms->symMap[&other];
+}
+
 // This function is called after we obtain a complete list of input sections
 // that need to be linked. This is responsible to split section contents
 // into small chunks for further processing.
@@ -1419,6 +1477,10 @@ void MergeInputSection::splitIntoPieces() {
     splitStrings(toStringRef(contentMaybeDecompress()), entsize);
   else
     splitNonStrings(contentMaybeDecompress(), entsize);
+
+  for (MergeInputSection *ms : clones)
+    if (ms)
+      ms->splitIntoPieces();
 }
 
 SectionPiece &MergeInputSection::getSectionPiece(uint64_t offset) {

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -1410,8 +1410,11 @@ MergeInputSection::MergeInputSection(uint64_t flags, uint32_t type,
 
 MergeInputSection::MergeInputSection(const Compartment &c,
                                      const MergeInputSection &other)
-    : InputSectionBase(other) {
-  name = saver().save(other.name + c.suffix);
+    : InputSectionBase(other.file, other.flags & ~SHF_COMPRESSED, other.type,
+                       other.entsize, /*Link*/ 0, /*Info*/ 0, other.addralign,
+                       other.contentMaybeDecompress(),
+                       saver().save(other.name + c.suffix),
+                       SectionBase::Merge) {
   compartment = c.getNumber();
 }
 

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -658,8 +658,8 @@ static int64_t getTlsTpOffset(const Symbol &s) {
   return getTpOffset(s.getVA(0), Out::tlsPhdr);
 }
 
-static int64_t getTgotTpOffset(const Symbol &s) {
-  return getTpOffset(s.getTgotVA(), Out::tgotPhdr);
+static int64_t getTgotTpOffset(const Compartment &c, const Symbol &s) {
+  return getTpOffset(s.getTgotVA(c), Out::tgotPhdr);
 }
 
 uint64_t InputSectionBase::getRelocTargetVA(const InputFile *file, RelType type,
@@ -667,6 +667,7 @@ uint64_t InputSectionBase::getRelocTargetVA(const InputFile *file, RelType type,
                                             const Symbol &sym, RelExpr expr,
                                             const InputSectionBase *isec,
                                             uint64_t offset) {
+  const Compartment &c = isec->getCompartment();
   switch (expr) {
   case R_ABS:
   case R_DTPREL:
@@ -682,43 +683,44 @@ uint64_t InputSectionBase::getRelocTargetVA(const InputFile *file, RelType type,
     return sym.getVA(a) - getARMStaticBase(sym);
   case R_GOT:
   case R_RELAX_TLS_GD_TO_IE_ABS:
-    return sym.getGotVA() + a;
-  case R_LOONGARCH_GOT:
+    return sym.getGotVA(c) + a;
+  case R_LOONGARCH_GOT: {
     // The LoongArch TLS GD relocs reuse the R_LARCH_GOT_PC_LO12 reloc type
     // for their page offsets. The arithmetics are different in the TLS case
     // so we have to duplicate some logic here.
-    if (sym.hasFlag(NEEDS_TLSGD) && type != R_LARCH_TLS_IE_PC_LO12)
+    if (sym.hasFlag(c, NEEDS_TLSGD) && type != R_LARCH_TLS_IE_PC_LO12)
       // Like R_LOONGARCH_TLSGD_PAGE_PC but taking the absolute value.
-      return in.got->getGlobalDynAddr(sym) + a;
+      return c.got->getGlobalDynAddr(sym) + a;
     return getRelocTargetVA(file, type, a, p, sym, R_GOT, isec, offset);
+  }
   case R_GOTONLY_PC:
-    return in.got->getVA() + a - p;
+    return c.got->getVA() + a - p;
   case R_GOTPLTONLY_PC:
-    return in.gotPlt->getVA() + a - p;
+    return c.gotPlt->getVA() + a - p;
   case R_GOTREL:
   case R_PPC64_RELAX_TOC:
-    return sym.getVA(a) - in.got->getVA();
+    return sym.getVA(a) - c.got->getVA();
   case R_GOTPLTREL:
-    return sym.getVA(a) - in.gotPlt->getVA();
+    return sym.getVA(a) - c.gotPlt->getVA();
   case R_GOTPLT:
   case R_RELAX_TLS_GD_TO_IE_GOTPLT:
-    return sym.getGotVA() + a - in.gotPlt->getVA();
+    return sym.getGotVA(c) + a - c.gotPlt->getVA();
   case R_TLSLD_GOT_OFF:
   case R_GOT_OFF:
   case R_RELAX_TLS_GD_TO_IE_GOT_OFF:
-    return sym.getGotOffset() + a;
+    return sym.getGotOffset(c) + a;
   case R_AARCH64_GOT_PAGE_PC:
   case R_AARCH64_RELAX_TLS_GD_TO_IE_PAGE_PC:
-    return getAArch64Page(sym.getGotVA() + a) - getAArch64Page(p);
+    return getAArch64Page(sym.getGotVA(c) + a) - getAArch64Page(p);
   case R_AARCH64_GOT_PAGE:
-    return sym.getGotVA() + a - getAArch64Page(in.got->getVA());
+    return sym.getGotVA(c) + a - getAArch64Page(c.got->getVA());
   case R_GOT_PC:
   case R_RELAX_TLS_GD_TO_IE:
-    return sym.getGotVA() + a - p;
+    return sym.getGotVA(c) + a - p;
   case R_LOONGARCH_GOT_PAGE_PC:
-    if (sym.hasFlag(NEEDS_TLSGD))
-      return getLoongArchPageDelta(in.got->getGlobalDynAddr(sym) + a, p);
-    return getLoongArchPageDelta(sym.getGotVA() + a, p);
+    if (sym.hasFlag(c, NEEDS_TLSGD))
+      return getLoongArchPageDelta(c.got->getGlobalDynAddr(sym) + a, p);
+    return getLoongArchPageDelta(sym.getGotVA(c) + a, p);
   case R_MIPS_GOTREL:
     return sym.getVA(a) - in.mipsGot->getGp(file);
   case R_MIPS_GOT_GP:
@@ -798,19 +800,19 @@ uint64_t InputSectionBase::getRelocTargetVA(const InputFile *file, RelType type,
     return dest - p;
   }
   case R_PLT:
-    return sym.getPltVA() + a;
+    return sym.getPltVA(c) + a;
   case R_PLT_PC:
   case R_PPC64_CALL_PLT:
-    return sym.getPltVA() + a - p;
+    return sym.getPltVA(c) + a - p;
   case R_LOONGARCH_PLT_PAGE_PC:
-    return getLoongArchPageDelta(sym.getPltVA() + a, p);
+    return getLoongArchPageDelta(sym.getPltVA(c) + a, p);
   case R_PLT_GOTPLT:
-    return sym.getPltVA() + a - in.gotPlt->getVA();
+    return sym.getPltVA(c) + a - c.gotPlt->getVA();
   case R_PPC32_PLTREL:
     // R_PPC_PLTREL24 uses the addend (usually 0 or 0x8000) to indicate r30
     // stores _GLOBAL_OFFSET_TABLE_ or .got2+0x8000. The addend is ignored for
     // target VA computation.
-    return sym.getPltVA() - p;
+    return sym.getPltVA(c) - p;
   case R_PPC64_CALL: {
     uint64_t symVA = sym.getVA(a);
     // If we have an undefined weak symbol, we might get here with a symbol
@@ -851,43 +853,43 @@ uint64_t InputSectionBase::getRelocTargetVA(const InputFile *file, RelType type,
   case R_SIZE:
     return sym.getSize() + a;
   case R_TLSDESC:
-    return in.got->getTlsDescAddr(sym) + a;
+    return c.got->getTlsDescAddr(sym) + a;
   case R_TLSDESC_PC:
-    return in.got->getTlsDescAddr(sym) + a - p;
+    return c.got->getTlsDescAddr(sym) + a - p;
   case R_TLSDESC_GOTPLT:
-    return in.got->getTlsDescAddr(sym) + a - in.gotPlt->getVA();
+    return c.got->getTlsDescAddr(sym) + a - c.gotPlt->getVA();
   case R_AARCH64_TLSDESC_PAGE:
-    return getAArch64Page(in.got->getTlsDescAddr(sym) + a) - getAArch64Page(p);
+    return getAArch64Page(c.got->getTlsDescAddr(sym) + a) - getAArch64Page(p);
   case R_TLSGD_GOT:
-    return in.got->getGlobalDynOffset(sym) + a;
+    return c.got->getGlobalDynOffset(sym) + a;
   case R_TLSGD_GOTPLT:
-    return in.got->getGlobalDynAddr(sym) + a - in.gotPlt->getVA();
+    return c.got->getGlobalDynAddr(sym) + a - c.gotPlt->getVA();
   case R_TLSGD_PC:
-    return in.got->getGlobalDynAddr(sym) + a - p;
+    return c.got->getGlobalDynAddr(sym) + a - p;
   case R_LOONGARCH_TLSGD_PAGE_PC:
-    return getLoongArchPageDelta(in.got->getGlobalDynAddr(sym) + a, p);
+    return getLoongArchPageDelta(c.got->getGlobalDynAddr(sym) + a, p);
   case R_TLSLD_GOTPLT:
-    return in.got->getVA() + in.got->getTlsIndexOff() + a - in.gotPlt->getVA();
+    return c.got->getVA() + c.got->getTlsIndexOff() + a - c.gotPlt->getVA();
   case R_TLSLD_GOT:
-    return in.got->getTlsIndexOff() + a;
+    return c.got->getTlsIndexOff() + a;
   case R_TLSLD_PC:
-    return in.got->getTlsIndexVA() + a - p;
+    return c.got->getTlsIndexVA() + a - p;
   case R_TGOT:
-    return sym.getTgotVA() + a;
+    return sym.getTgotVA(c) + a;
   case R_TGOT_TP:
   case R_RELAX_TGOT_TLS_GD_TO_LE:
   case R_RELAX_TGOT_TLS_IE_TO_LE:
-    return getTgotTpOffset(sym) + a;
+    return getTgotTpOffset(c, sym) + a;
   case R_TGOT_GOT:
   case R_RELAX_TGOT_TLS_GD_TO_IE_ABS:
-    return in.got->getTgotAddr(sym) + a;
+    return c.got->getTgotAddr(sym) + a;
   case R_TGOT_GOT_PC:
   case R_RELAX_TGOT_TLS_GD_TO_IE:
-    return in.got->getTgotAddr(sym) + a - p;
+    return c.got->getTgotAddr(sym) + a - p;
   case R_TGOT_TLSDESC:
-    return in.got->getTgotTlsDescAddr(sym) + a;
+    return c.got->getTgotTlsDescAddr(sym) + a;
   case R_TGOT_TLSGD_PC:
-    return in.got->getTgotGlobalDynAddr(sym) + a - p;
+    return c.got->getTgotGlobalDynAddr(sym) + a - p;
   case R_ABS_CAP:
     llvm_unreachable("R_ABS_CAP should not be handled here!");
   case R_ABS_CAP_ADDR:

--- a/lld/ELF/InputSection.h
+++ b/lld/ELF/InputSection.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Object/ELF.h"
 #include "llvm/Support/Compiler.h"
+#include <unordered_map>
 
 namespace lld {
 namespace elf {
@@ -295,6 +296,10 @@ public:
                     StringRef name);
   MergeInputSection(uint64_t flags, uint32_t type, uint64_t entsize,
                     ArrayRef<uint8_t> data, StringRef name);
+  MergeInputSection(const Compartment &c, const MergeInputSection &other);
+
+  MergeInputSection *clone(const Compartment &c);
+  Symbol &getCompartmentSymbol(const Compartment &c, Symbol &other);
 
   static bool classof(const SectionBase *s) { return s->kind() == Merge; }
   void splitIntoPieces();
@@ -328,6 +333,15 @@ public:
   }
 
 private:
+  // Each compartment contains its own copy of each merge section.
+  SmallVector<MergeInputSection *, 0> clones;
+
+  // Clones contain private symbols that are clones of symbols for the original
+  // section.
+  std::unordered_map<Symbol *, Defined *> symMap;
+
+  void cloneSymbols(const MergeInputSection *other);
+
   void splitStrings(StringRef s, size_t size);
   void splitNonStrings(ArrayRef<uint8_t> a, size_t size);
 };

--- a/lld/ELF/InputSection.h
+++ b/lld/ELF/InputSection.h
@@ -26,11 +26,15 @@ namespace elf {
 class InputFile;
 class Symbol;
 
+struct Compartment;
 class Defined;
 struct Partition;
 class SyntheticSection;
 template <class ELFT> class ObjFile;
 class OutputSection;
+
+LLVM_LIBRARY_VISIBILITY extern std::vector<Compartment> compartments;
+LLVM_LIBRARY_VISIBILITY extern Compartment *defaultCompart;
 
 LLVM_LIBRARY_VISIBILITY extern std::vector<Partition> partitions;
 
@@ -62,6 +66,7 @@ public:
   uint8_t keepUnique : 1;
 
   uint8_t partition = 1;
+  uint8_t compartment = 0;
   uint32_t type;
   StringRef name;
 
@@ -69,6 +74,8 @@ public:
   // collector, or 0 if this section is dead. Normally there is only one
   // partition, so this will either be 0 or 1.
   elf::Partition &getPartition() const;
+
+  elf::Compartment &getCompartment() const;
 
   // These corresponds to the fields in Elf_Shdr.
   uint64_t flags;

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -50,7 +50,7 @@ static bool isSectionPrefix(StringRef prefix, StringRef name) {
   return name.consume_front(prefix) && (name.empty() || name[0] == '.');
 }
 
-static StringRef getOutputSectionName(const InputSectionBase *s) {
+static StringRef getOutputSectionBaseName(const InputSectionBase *s) {
   if (config->relocatable)
     return s->name;
 
@@ -71,7 +71,8 @@ static StringRef getOutputSectionName(const InputSectionBase *s) {
   if (s->name == "COMMON")
     return ".bss";
 
-  if (script->hasSectionsCommand)
+  // SECTIONS only applies to the default compartment, so ignore for others.
+  if (script->hasSectionsCommand && s->compartment == 0)
     return s->name;
 
   // When no SECTIONS is specified, emulate GNU ld's internal linker scripts
@@ -108,6 +109,13 @@ static StringRef getOutputSectionName(const InputSectionBase *s) {
       return v;
 
   return s->name;
+}
+
+static StringRef getOutputSectionName(const InputSectionBase *s) {
+  StringRef name = getOutputSectionBaseName(s);
+  if (s->compartment != 0)
+    name = saver().save(name + s->getCompartment().suffix);
+  return name;
 }
 
 uint64_t ExprValue::getValue() const {
@@ -508,6 +516,10 @@ LinkerScript::computeInputSections(const InputSectionDescription *cmd,
       if (!sec->isLive() || sec->parent || seen.contains(i))
         continue;
 
+      // Ignore sections in a compartment
+      if (sec->compartment != 0)
+        continue;
+
       // For --emit-relocs we have to ignore entries like
       //   .rela.dyn : { *(.rela.data) }
       // which are common because they are in the default bfd script.
@@ -789,6 +801,8 @@ static OutputDesc *addInputSec(StringMap<TinyPtrVector<OutputSection *>> &map,
   TinyPtrVector<OutputSection *> &v = map[outsecName];
   for (OutputSection *sec : v) {
     if (sec->partition != isec->partition)
+      continue;
+    if (sec->compartment != isec->compartment)
       continue;
 
     if (config->relocatable && (isec->flags & SHF_LINK_ORDER)) {

--- a/lld/ELF/MapFile.cpp
+++ b/lld/ELF/MapFile.cpp
@@ -59,7 +59,7 @@ static std::vector<Defined *> getSymbols() {
     for (Symbol *b : file->getSymbols())
       if (auto *dr = dyn_cast<Defined>(b))
         if (!dr->isSection() && dr->section && dr->section->isLive() &&
-            (dr->file == file || dr->hasFlag(NEEDS_COPY) || dr->section->bss))
+            (dr->file == file || dr->needsCopyAny || dr->section->bss))
           v.push_back(dr);
   return v;
 }

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -89,7 +89,8 @@ template <class ELFT>
 template <class RelTy>
 void MarkLive<ELFT>::resolveReloc(InputSectionBase &sec, RelTy &rel,
                                   bool fromFDE) {
-  Symbol &sym = sec.getFile<ELFT>()->getRelocTargetSym(rel);
+  Symbol &sym =
+      sec.getFile<ELFT>()->getRelocTargetSym(sec.getCompartment(), rel);
 
   // If a symbol is referenced in a live section, it is used.
   sym.used = true;

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -143,6 +143,14 @@ def : Flag<["--"], "color-diagnostics">, Alias<color_diagnostics>, AliasArgs<["a
 def : Flag<["--"], "no-color-diagnostics">, Alias<color_diagnostics>, AliasArgs<["never"]>,
   HelpText<"Alias for --color-diagnostics=never">;
 
+defm compartment: EEq<"compartment", "Set the containing compartment of the inputs following this option">,
+  MetaVarName<"<compart>">;
+
+defm compartment_policy: EEq<"compartment-policy", "Use a policy file to split output into compartments">,
+  MetaVarName<"<file>">;
+
+def verbose_c18n : F<"verbose-c18n">, HelpText<"Log compartmentalization policy inferences">;
+
 def cref: FF<"cref">,
   HelpText<"Output cross reference table. If -Map is specified, print to the map file">;
 
@@ -301,6 +309,9 @@ def nmagic: F<"nmagic">, MetaVarName<"<magic>">,
 
 def nostdlib: F<"nostdlib">,
   HelpText<"Only search directories specified on the command line">;
+
+def no_default_compartment: F<"no-default-compartment">,
+  HelpText<"Do not permit input sections in the default compartment">;
 
 def no_dynamic_linker: F<"no-dynamic-linker">,
   HelpText<"Inhibit output of .interp section">;

--- a/lld/ELF/OutputSections.cpp
+++ b/lld/ELF/OutputSections.cpp
@@ -102,6 +102,7 @@ static bool canMergeToProgbits(unsigned type) {
 // 3. Call commitSection(isec).
 void OutputSection::recordSection(InputSectionBase *isec) {
   partition = isec->partition;
+  compartment = isec->compartment;
   isec->parent = this;
   if (commands.empty() || !isa<InputSectionDescription>(commands.back()))
     commands.push_back(make<InputSectionDescription>(""));

--- a/lld/ELF/OutputSections.h
+++ b/lld/ELF/OutputSections.h
@@ -75,6 +75,9 @@ public:
   // Sections accessed using PCC on CHERI architectures.
   std::atomic<bool> cheriPcc{false};
 
+  // This section is the first section after the end of a relro segment.
+  bool relroEnd = false;
+
   void recordSection(InputSectionBase *isec);
   void commitSection(InputSection *isec);
   void finalizeInputSections();

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1564,9 +1564,8 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
 
 template <class ELFT, class RelTy> void RelocationScanner::scanOne(RelTy *&i) {
   const RelTy &rel = *i;
-  uint32_t symIndex = rel.getSymbol(config->isMips64EL);
-  Symbol &sym = sec->getFile<ELFT>()->getSymbol(symIndex);
   Compartment &c = sec->getCompartment();
+  Symbol &sym = sec->getFile<ELFT>()->getRelocTargetSym(c, rel);
   RelType type;
   if (config->mipsN32Abi) {
     type = getMipsN32RelType(i);
@@ -1595,6 +1594,7 @@ template <class ELFT, class RelTy> void RelocationScanner::scanOne(RelTy *&i) {
 
   // Error if the target symbol is undefined. Symbol index 0 may be used by
   // marker relocations, e.g. R_*_NONE and R_ARM_V4BX. Don't error on them.
+  uint32_t symIndex = rel.getSymbol(config->isMips64EL);
   if (sym.isUndefined() && symIndex != 0 &&
       maybeReportUndefined(cast<Undefined>(sym), *sec, offset))
     return;
@@ -2037,6 +2037,10 @@ void elf::postScanRelocations() {
     for (Symbol *sym : file->getLocalSymbols())
       for (Compartment &c : compartments)
         fn(c, *sym);
+
+  for (Symbol *sym : ctx.compartSymbols)
+    for (Compartment &c : compartments)
+      fn(c, *sym);
 }
 
 static bool mergeCmp(const InputSection *a, const InputSection *b) {

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -331,9 +331,17 @@ static void replaceWithDefined(Symbol &sym, SectionBase &sec, uint64_t value,
   sym.verdefIndex = old.verdefIndex;
   sym.exportDynamic = true;
   sym.isUsedInRegularObj = true;
+
   // A copy relocated alias may need a GOT entry.
-  sym.flags.store(old.flags.load(std::memory_order_relaxed) & NEEDS_GOT,
-                  std::memory_order_relaxed);
+  // NB: compartAux not copied for old, but preserved on sym; modify in-place.
+  for (Compartment &c : compartments) {
+    const SymbolCompartAux &aux = sym.compartAux(c);
+    if (&aux == &defaultSymbolCompartAux)
+      continue;
+    const_cast<SymbolCompartAux &>(aux).flags.fetch_and(
+        NEEDS_GOT, std::memory_order_relaxed);
+  }
+  sym.needsCopyAny = false;
 }
 
 // Reserve space in .bss or .bss.rel.ro for copy relocation.
@@ -921,31 +929,32 @@ static void addPltEntry(PltSection &plt, GotPltSection &gotPlt,
   plt.addEntry(sym);
   gotPlt.addEntry(sym);
 
+  Compartment &c = gotPlt.getCompartment();
   if (config->isCheriAbi && !config->useRelativeElfCheriRelocs) {
     if (!sym.isPreemptible) {
-      mainPart->capRelocs->addReloc(gotPlt, sym.getGotPltOffset(), sym, 0,
+      mainPart->capRelocs->addReloc(gotPlt, sym.getGotPltOffset(c), sym, 0,
                                     R_ABS_CAP, *target->symbolicCapRel);
       return;
     }
 
-    mainPart->capRelocs->addReloc(gotPlt, sym.getGotPltOffset(), plt, 0,
+    mainPart->capRelocs->addReloc(gotPlt, sym.getGotPltOffset(c), plt, 0,
                                   R_ABS_CAP, *target->symbolicCodeCapRel);
   }
 
-  rel.addReloc({type, &gotPlt, sym.getGotPltOffset(),
+  rel.addReloc({type, &gotPlt, sym.getGotPltOffset(c),
                 sym.isPreemptible ? DynamicReloc::AgainstSymbol
                                   : DynamicReloc::AddendOnlyWithTargetVA,
                 sym, 0, R_ABS});
 }
 
-static void addGotEntry(Symbol &sym) {
-  in.got->addEntry(sym);
-  uint64_t off = sym.getGotOffset();
+static void addGotEntry(Compartment &c, Symbol &sym) {
+  c.got->addEntry(sym);
+  uint64_t off = sym.getGotOffset(c);
   RelExpr expr = config->isCheriAbi ? R_ABS_CAP : R_ABS;
 
   // If preemptible, emit a GLOB_DAT relocation.
   if (sym.isPreemptible) {
-    mainPart->relaDyn->addReloc({target->gotRel, in.got.get(), off,
+    mainPart->relaDyn->addReloc({target->gotRel, c.got.get(), off,
                                  DynamicReloc::AgainstSymbol, sym, 0, expr});
     return;
   }
@@ -958,29 +967,29 @@ static void addGotEntry(Symbol &sym) {
   // with the exception of undef weak symbols.
   if ((config->isCheriAbi && sym.isUndefWeak()) ||
       (!config->isCheriAbi && (!config->isPic || isAbsolute(sym))))
-    in.got->addConstant({expr, type, off, 0, &sym});
+    c.got->addConstant({expr, type, off, 0, &sym});
   else
-    addRelativeReloc(*in.got, off, sym, 0, expr, type);
+    addRelativeReloc(*c.got, off, sym, 0, expr, type);
 }
 
-static void addTpOffsetGotEntry(Symbol &sym) {
-  in.got->addEntry(sym);
-  uint64_t off = sym.getGotOffset();
+static void addTpOffsetGotEntry(Compartment &c, Symbol &sym) {
+  c.got->addEntry(sym);
+  uint64_t off = sym.getGotOffset(c);
   if (!sym.isPreemptible && !config->isPic) {
-    in.got->addConstant({R_TPREL, target->symbolicRel, off, 0, &sym});
+    c.got->addConstant({R_TPREL, target->symbolicRel, off, 0, &sym});
     return;
   }
   mainPart->relaDyn->addAddendOnlyRelocIfNonPreemptible(
-      target->tlsGotRel, *in.got, off, sym, target->symbolicRel);
+      target->tlsGotRel, *c.got, off, sym, target->symbolicRel);
 }
 
-static void addTgotEntry(Symbol &sym) {
-  in.tgot->addEntry(sym);
-  uint64_t off = sym.getTgotOffset();
+static void addTgotEntry(Compartment &c, Symbol &sym) {
+  c.tgot->addEntry(sym);
+  uint64_t off = sym.getTgotOffset(c);
 
   // If preemptible, emit a TGOT_SLOT relocation with a symbol.
   if (sym.isPreemptible) {
-    in.relaTgot->addReloc({target->tgotRel, in.tgot.get(), off,
+    in.relaTgot->addReloc({target->tgotRel, c.tgot.get(), off,
                            DynamicReloc::AgainstSymbol, sym, 0, R_ADDEND});
     return;
   }
@@ -992,12 +1001,12 @@ static void addTgotEntry(Symbol &sym) {
   // Otherwise, the value is either an undef weak link-time constant or
   // relative to this module's TLS block.
   if (sym.isUndefWeak())
-    in.tgot->addConstant({expr, type, off, 0, &sym});
+    c.tgot->addConstant({expr, type, off, 0, &sym});
   else if (config->isCheriAbi && !config->useRelativeElfCheriRelocs)
-    in.tgotCapRelocs->addReloc(*in.tgot, off, sym, 0, expr, type);
+    in.tgotCapRelocs->addReloc(*c.tgot, off, sym, 0, expr, type);
   else
     in.relaTgot->addReloc(DynamicReloc::AddendOnlyWithTargetVA, target->tgotRel,
-                          *in.tgot, off, sym, 0, expr, type);
+                          *c.tgot, off, sym, 0, expr, type);
 }
 
 // Return true if we can define a symbol in the executable that
@@ -1119,10 +1128,15 @@ bool RelocationScanner::isStaticLinkTimeConstant(RelExpr e, RelType type,
 // space for the extra PT_LOAD even if we end up not using it.
 void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
                                    Symbol &sym, int64_t addend) const {
+  Compartment *symCompartment = sym.containingCompartment();
+  bool crossCompartment =
+      symCompartment && symCompartment != &sec->getCompartment();
+
   // If non-ifunc non-preemptible, change PLT to direct call and optimize GOT
   // indirection.
   const bool isIfunc = sym.isGnuIFunc();
-  if (!sym.isPreemptible && (!isIfunc || config->zIfuncNoplt)) {
+  if (!sym.isPreemptible && (!isIfunc || config->zIfuncNoplt) &&
+      !crossCompartment) {
     if (expr != R_GOT_PC) {
       // The 0x8000 bit of r_addend of R_PPC_PLTREL24 is used to choose call
       // stub type. It should be ignored if optimized to R_PC.
@@ -1180,14 +1194,19 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
     } else if (!sym.isTls() || config->emachine != EM_LOONGARCH) {
       // Many LoongArch TLS relocs reuse the R_LOONGARCH_GOT type, in which
       // case the NEEDS_GOT flag shouldn't get set.
-      sym.setFlags(NEEDS_GOT);
+      sym.setFlags(sec->getCompartment(), NEEDS_GOT);
     }
   } else if (needsMipsCheriCapTable(expr)) {
     in.mipsCheriCapTable->addEntry(sym, expr, sec, offset);
   } else if (needsPlt(expr)) {
-    sym.setFlags(NEEDS_PLT);
+    sym.setFlags(sec->getCompartment(), NEEDS_PLT);
   } else if (LLVM_UNLIKELY(isIfunc)) {
-    sym.setFlags(HAS_DIRECT_RELOC);
+    // Direct references to non-preemptible ifuncs should reference the IPLT
+    // stub in the compartment containing the resolver, not the calling
+    // compartment.
+    auto symCompart = sym.containingCompartment();
+    assert(symCompart && "ifunc not contained in a compartment");
+    sym.setFlags(*symCompart, HAS_DIRECT_RELOC);
   }
 
   // If the relocation is known to be a link-time constant, we know no dynamic
@@ -1286,7 +1305,8 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
                 " against symbol '" + toString(*ss) +
                 "'; recompile with -fPIC or remove '-z nocopyreloc'" +
                 getLocation(*sec, sym, offset));
-        sym.setFlags(NEEDS_COPY);
+        sym.setFlags(sec->getCompartment(), NEEDS_COPY);
+        sym.needsCopyAny = true;
       }
       sec->addReloc({expr, type, offset, addend, &sym});
       return;
@@ -1324,7 +1344,8 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
         errorOrWarn("symbol '" + toString(sym) +
                     "' cannot be preempted; recompile with -fPIE" +
                     getLocation(*sec, sym, offset));
-      sym.setFlags(NEEDS_COPY | NEEDS_PLT);
+      sym.setFlags(sec->getCompartment(), NEEDS_COPY | NEEDS_PLT);
+      sym.needsCopyAny = true;
       sec->addReloc({expr, type, offset, addend, &sym});
       return;
     }
@@ -1389,7 +1410,7 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
 
   if (oneof<R_TPREL, R_TPREL_NEG, R_TGOT, R_TGOT_TP>(expr)) {
     if (isTgot)
-      sym.setFlags(NEEDS_TGOT);
+      sym.setFlags(c.getCompartment(), NEEDS_TGOT);
 
     if (config->shared) {
       errorOrWarn("relocation " + toString(type) + " against " + toString(sym) +
@@ -1403,16 +1424,16 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
     return handleMipsTlsRelocation(type, sym, c, offset, addend, expr);
 
   if (isTgot)
-    sym.setFlags(NEEDS_TGOT);
+    sym.setFlags(c.getCompartment(), NEEDS_TGOT);
 
   if (oneof<R_AARCH64_TLSDESC_PAGE, R_TLSDESC, R_TLSDESC_CALL, R_TLSDESC_PC,
             R_TLSDESC_GOTPLT, R_TGOT_TLSDESC, R_TGOT_TLSDESC_CALL>(expr) &&
       config->shared) {
     if (!oneof<R_TLSDESC_CALL, R_TGOT_TLSDESC_CALL>(expr)) {
       if (isTgot)
-        sym.setFlags(NEEDS_TGOT_TLSDESC);
+        sym.setFlags(c.getCompartment(), NEEDS_TGOT_TLSDESC);
       else
-        sym.setFlags(NEEDS_TLSDESC);
+        sym.setFlags(c.getCompartment(), NEEDS_TLSDESC);
       c.addReloc({expr, type, offset, addend, &sym});
     }
     return 1;
@@ -1466,7 +1487,7 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
   // Local-Dynamic sequence where offset of tls variable relative to dynamic
   // thread pointer is stored in the got. This cannot be relaxed to Local-Exec.
   if (expr == R_TLSLD_GOT_OFF) {
-    sym.setFlags(NEEDS_GOT_DTPREL);
+    sym.setFlags(c.getCompartment(), NEEDS_GOT_DTPREL);
     c.addReloc({expr, type, offset, addend, &sym});
     return 1;
   }
@@ -1477,9 +1498,9 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
             R_LOONGARCH_TLSGD_PAGE_PC>(expr)) {
     if (!toExecRelax) {
       if (isTgot)
-        sym.setFlags(NEEDS_TGOT_TLSGD);
+        sym.setFlags(c.getCompartment(), NEEDS_TGOT_TLSGD);
       else
-        sym.setFlags(NEEDS_TLSGD);
+        sym.setFlags(c.getCompartment(), NEEDS_TLSGD);
       c.addReloc({expr, type, offset, addend, &sym});
       return 1;
     }
@@ -1490,10 +1511,10 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
     if (sym.isPreemptible && !isTgot) {
       RelExpr relaxExpr;
       if (isTgot) {
-        sym.setFlags(NEEDS_TGOT_GOT);
+        sym.setFlags(c.getCompartment(), NEEDS_TGOT_GOT);
         relaxExpr = R_RELAX_TGOT_TLS_GD_TO_IE;
       } else {
-        sym.setFlags(NEEDS_TLSIE);
+        sym.setFlags(c.getCompartment(), NEEDS_TLSIE);
         relaxExpr = R_RELAX_TLS_GD_TO_IE;
       }
       c.addReloc(
@@ -1526,9 +1547,9 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
       c.addReloc({relaxExpr, type, offset, addend, &sym});
     } else if (expr != R_TLSIE_HINT) {
       if (isTgot)
-        sym.setFlags(NEEDS_TGOT_GOT);
+        sym.setFlags(c.getCompartment(), NEEDS_TGOT_GOT);
       else
-        sym.setFlags(NEEDS_TLSIE);
+        sym.setFlags(c.getCompartment(), NEEDS_TLSIE);
       // R_GOT needs a relative relocation for PIC on i386 and Hexagon.
       if (expr == R_GOT && config->isPic && !target->usesOnlyLowPageBits(type))
         addRelativeReloc<true>(c, offset, sym, addend, expr, type);
@@ -1545,6 +1566,7 @@ template <class ELFT, class RelTy> void RelocationScanner::scanOne(RelTy *&i) {
   const RelTy &rel = *i;
   uint32_t symIndex = rel.getSymbol(config->isMips64EL);
   Symbol &sym = sec->getFile<ELFT>()->getSymbol(symIndex);
+  Compartment &c = sec->getCompartment();
   RelType type;
   if (config->mipsN32Abi) {
     type = getMipsN32RelType(i);
@@ -1617,10 +1639,10 @@ template <class ELFT, class RelTy> void RelocationScanner::scanOne(RelTy *&i) {
   // The 5 types that relative GOTPLT are all x86 and x86-64 specific.
   if (oneof<R_GOTPLTONLY_PC, R_GOTPLTREL, R_GOTPLT, R_PLT_GOTPLT,
             R_TLSDESC_GOTPLT, R_TLSGD_GOTPLT>(expr)) {
-    in.gotPlt->hasGotPltOffRel.store(true, std::memory_order_relaxed);
+    c.gotPlt->hasGotPltOffRel.store(true, std::memory_order_relaxed);
   } else if (oneof<R_GOTONLY_PC, R_GOTREL, R_PPC32_PLTREL, R_PPC64_TOCBASE,
                    R_PPC64_RELAX_TOC>(expr)) {
-    in.got->hasGotOffRel.store(true, std::memory_order_relaxed);
+    c.got->hasGotOffRel.store(true, std::memory_order_relaxed);
   }
 
   // Process TLS relocations, including relaxing TLS relocations. Note that
@@ -1749,7 +1771,8 @@ template <class ELFT> void elf::scanRelocations() {
   });
 }
 
-static bool handleNonPreemptibleIfunc(Symbol &sym, uint16_t flags) {
+static bool handleNonPreemptibleIfunc(Compartment &c, Symbol &sym,
+                                      uint16_t flags) {
   // Handle a reference to a non-preemptible ifunc. These are special in a
   // few ways:
   //
@@ -1796,24 +1819,27 @@ static bool handleNonPreemptibleIfunc(Symbol &sym, uint16_t flags) {
   if (!(flags & (NEEDS_GOT | NEEDS_PLT | HAS_DIRECT_RELOC)))
     return true;
 
-  sym.isInIplt = true;
+  SymbolCompartAux &aux = sym.mutableCompartAux(c);
+  aux.isInIplt = true;
 
   // Create an Iplt and the associated IRELATIVE relocation pointing to the
   // original section/value pairs. For non-GOT non-PLT relocation case below, we
   // may alter section/value, so create a copy of the symbol to make
   // section/value fixed.
   auto *directSym = makeDefined(cast<Defined>(sym));
-  directSym->allocateAux();
-  addPltEntry(*in.iplt, *in.igotPlt, *in.relaIplt, target->iRelativeRel,
+  SymbolCompartAux &directAux = directSym->mutableCompartAux(c);
+  directAux = aux;
+  directSym->allocateAux(c);
+  addPltEntry(*c.iplt, *c.igotPlt, *in.relaIplt, target->iRelativeRel,
               *directSym);
-  sym.allocateAux();
-  symAux.back().pltIdx = symAux[directSym->auxIdx].pltIdx;
+  sym.allocateAux(c);
+  symAux.back().pltIdx = symAux[directSym->auxIdx(c)].pltIdx;
 
   if (flags & HAS_DIRECT_RELOC) {
     // Change the value to the IPLT and redirect all references to it.
     auto &d = cast<Defined>(sym);
-    d.section = in.iplt.get();
-    d.value = d.getPltIdx() * target->ipltEntrySize;
+    d.section = c.iplt.get();
+    d.value = d.getPltIdx(c) * target->ipltEntrySize;
     if (config->isCheriAbi)
       d.setSize(target->ipltEntrySize);
     else
@@ -1823,46 +1849,87 @@ static bool handleNonPreemptibleIfunc(Symbol &sym, uint16_t flags) {
     d.type = STT_FUNC;
 
     if (flags & NEEDS_GOT)
-      addGotEntry(sym);
+      addGotEntry(c, sym);
   } else if (flags & NEEDS_GOT) {
     // Redirect GOT accesses to point to the Igot.
-    sym.gotInIgot = true;
+    aux.gotInIgot = true;
+  }
+  return true;
+}
+
+static bool handleCrossCompartmentCall(Compartment &c, Symbol &sym,
+                                       uint16_t flags) {
+  // Handle a cross-compartment call to a non-preemptible function.
+  //
+  // These need to force indirection via a PLT stub.  These use a
+  // RELATIVE relocation rather than a typical jump slot relocation.
+  // Reuse the Iplt to hold the PLT stub.
+  if (sym.isPreemptible || !sym.isDefined() || !sym.isFunc() ||
+      !(flags & NEEDS_PLT))
+    return false;
+
+  auto symCompartment = sym.containingCompartment();
+  // When --just-symbols is active, undefined symbols are treated as
+  // defined symbols, but without a containing input section.
+  if (!symCompartment)
+    return false;
+
+  // Access within the same compartment is treated normally.
+  if (symCompartment == &c)
+    return false;
+
+  SymbolCompartAux &aux = sym.mutableCompartAux(c);
+  aux.isInIplt = true;
+
+  // Create an Iplt entry and the associated RELATIVE relocation.
+  sym.allocateAux(c);
+  addPltEntry(*c.iplt, *c.igotPlt, *mainPart->relaDyn, target->relativeRel,
+              sym);
+
+  if (flags & NEEDS_GOT) {
+    // Redirect GOT accesses to point to the Igot.
+    aux.gotInIgot = true;
   }
   return true;
 }
 
 void elf::postScanRelocations() {
-  auto fn = [](Symbol &sym) {
-    auto flags = sym.flags.load(std::memory_order_relaxed);
-    if (handleNonPreemptibleIfunc(sym, flags))
+  auto fn = [](Compartment &c, Symbol &sym) {
+    const SymbolCompartAux &aux = sym.compartAux(c);
+    auto flags = aux.flags.load(std::memory_order_relaxed);
+    if (handleNonPreemptibleIfunc(c, sym, flags))
       return;
-    if (!sym.needsDynReloc())
+    if (handleCrossCompartmentCall(c, sym, flags))
       return;
-    sym.allocateAux();
+    if (!sym.needsDynReloc(c))
+      return;
+    sym.allocateAux(c);
 
     if (flags & NEEDS_GOT)
-      addGotEntry(sym);
+      addGotEntry(c, sym);
     if (flags & NEEDS_PLT)
-      addPltEntry(*in.plt, *in.gotPlt, *in.relaPlt, target->pltRel, sym);
+      addPltEntry(*c.plt, *c.gotPlt, *c.relaPlt, target->pltRel, sym);
     if (flags & NEEDS_COPY) {
       if (sym.isObject()) {
         invokeELFT(addCopyRelSymbol, cast<SharedSymbol>(sym));
         // NEEDS_COPY is cleared for sym and its aliases so that in
         // later iterations aliases won't cause redundant copies.
-        assert(!sym.hasFlag(NEEDS_COPY));
+        assert(!aux.hasFlag(NEEDS_COPY));
       } else {
-        assert(sym.isFunc() && sym.hasFlag(NEEDS_PLT));
+        assert(sym.isFunc() && aux.hasFlag(NEEDS_PLT));
         if (!sym.isDefined()) {
-          replaceWithDefined(sym, *in.plt,
+          replaceWithDefined(sym, *c.plt,
                              target->pltHeaderSize +
-                                 target->pltEntrySize * sym.getPltIdx(),
+                                 target->pltEntrySize * sym.getPltIdx(c),
                              0);
-          sym.setFlags(NEEDS_COPY);
+          const_cast<SymbolCompartAux &>(aux).setFlags(NEEDS_COPY);
+          sym.needsCopyAny = true;
           if (config->emachine == EM_PPC) {
+            // XXXJHB: This would need to be per-compartment
             // PPC32 canonical PLT entries are at the beginning of .glink
-            cast<Defined>(sym).value = in.plt->headerSize;
-            in.plt->headerSize += 16;
-            cast<PPC32GlinkSection>(*in.plt).canonical_plts.push_back(&sym);
+            cast<Defined>(sym).value = c.plt->headerSize;
+            c.plt->headerSize += 16;
+            cast<PPC32GlinkSection>(*c.plt).canonical_plts.push_back(&sym);
           }
         }
       }
@@ -1871,7 +1938,7 @@ void elf::postScanRelocations() {
     if (!sym.isTls())
       return;
     bool isLocalInExecutable = !sym.isPreemptible && !config->shared;
-    GotSection *got = in.got.get();
+    GotSection *got = c.got.get();
 
     if (flags & NEEDS_TLSDESC) {
       got->addTlsDescEntry(sym);
@@ -1901,14 +1968,14 @@ void elf::postScanRelocations() {
     if (flags & NEEDS_GOT_DTPREL) {
       got->addEntry(sym);
       got->addConstant(
-          {R_ABS, target->tlsOffsetRel, sym.getGotOffset(), 0, &sym});
+          {R_ABS, target->tlsOffsetRel, sym.getGotOffset(c), 0, &sym});
     }
 
     if (flags & NEEDS_TLSIE)
-      addTpOffsetGotEntry(sym);
+      addTpOffsetGotEntry(c, sym);
 
     if (flags & NEEDS_TGOT)
-      addTgotEntry(sym);
+      addTgotEntry(c, sym);
 
     if (flags & NEEDS_TGOT_GOT) {
       got->addTgotEntry(sym);
@@ -1944,26 +2011,32 @@ void elf::postScanRelocations() {
     }
   };
 
-  GotSection *got = in.got.get();
-  if (ctx.needsTlsLd.load(std::memory_order_relaxed) && got->addTlsIndex()) {
-    static Undefined dummy(nullptr, "", STB_LOCAL, 0, 0);
-    if (config->shared)
-      mainPart->relaDyn->addReloc(
-          {target->tlsModuleIndexRel, got, got->getTlsIndexOff()});
-    else
-      got->addConstant(
-          {R_ADDEND, target->symbolicRel, got->getTlsIndexOff(), 1, &dummy});
+  if (ctx.needsTlsLd.load(std::memory_order_relaxed)) {
+    for (Compartment &c : compartments) {
+      GotSection *got = c.got.get();
+      if (got->addTlsIndex()) {
+        static Undefined dummy(nullptr, "", STB_LOCAL, 0, 0);
+        if (config->shared)
+          mainPart->relaDyn->addReloc(
+              {target->tlsModuleIndexRel, got, got->getTlsIndexOff()});
+        else
+          got->addConstant({R_ADDEND, target->symbolicRel,
+                            got->getTlsIndexOff(), 1, &dummy});
+      }
+    }
   }
 
   assert(symAux.size() == 1);
   for (Symbol *sym : symtab.getSymbols())
-    fn(*sym);
+    for (Compartment &c : compartments)
+      fn(c, *sym);
 
   // Local symbols may need the aforementioned non-preemptible ifunc and GOT
   // handling. They don't need regular PLT.
   for (ELFFileBase *file : ctx.objectFiles)
     for (Symbol *sym : file->getLocalSymbols())
-      fn(*sym);
+      for (Compartment &c : compartments)
+        fn(c, *sym);
 }
 
 static bool mergeCmp(const InputSection *a, const InputSection *b) {
@@ -2305,6 +2378,8 @@ static bool isThunkSectionCompatible(InputSection *source,
   // not be loaded. But partition 1 (the main partition) will always be loaded.
   if (source->partition != target->partition)
     return target->partition == 1;
+  if (source->compartment != target->compartment)
+    return false;
   return true;
 }
 
@@ -2324,7 +2399,7 @@ std::pair<Thunk *, bool> ThunkCreator::getThunk(InputSection *isec,
   // offset + addend) pair. We may revert the relocation back to its original
   // non-Thunk target, so we cannot fold offset + addend.
   if (auto *d = dyn_cast<Defined>(rel.sym))
-    if (!d->isInPlt() && d->section)
+    if (!d->isInPlt(isec->getCompartment()) && d->section)
       thunkVec = &thunkedSymbolsBySectionAndAddend[{{d->section, d->value},
                                                     keyAddend}];
   if (!thunkVec)
@@ -2348,13 +2423,14 @@ std::pair<Thunk *, bool> ThunkCreator::getThunk(InputSection *isec,
 // Return false if the relocation is not to a Thunk. If the relocation target
 // was originally to a Thunk, but is no longer in range we revert the
 // relocation back to its original non-Thunk target.
-bool ThunkCreator::normalizeExistingThunk(Relocation &rel, uint64_t src) {
+bool ThunkCreator::normalizeExistingThunk(Compartment &c, Relocation &rel,
+                                          uint64_t src) {
   if (Thunk *t = thunks.lookup(rel.sym)) {
     if (target->inBranchRange(rel.type, src, rel.sym->getVA(rel.addend)))
       return true;
     rel.sym = &t->destination;
     rel.addend = t->addend;
-    if (rel.sym->isInPlt())
+    if (rel.sym->isInPlt(c))
       rel.expr = toPlt(rel.expr);
   }
   return false;
@@ -2407,11 +2483,13 @@ bool ThunkCreator::createThunks(uint32_t pass,
             // If we are a relocation to an existing Thunk, check if it is
             // still in range. If not then Rel will be altered to point to its
             // original target so another Thunk can be generated.
-            if (pass > 0 && normalizeExistingThunk(rel, src))
+            if (pass > 0 &&
+                normalizeExistingThunk(isec->getCompartment(), rel, src))
               continue;
 
-            if (!target->needsThunk(rel.expr, rel.type, isec->file, src,
-                                    *rel.sym, rel.addend))
+            if (!target->needsThunk(rel.expr, rel.type, isec->file,
+                                    isec->getCompartment(), src, *rel.sym,
+                                    rel.addend))
               continue;
 
             Thunk *t;
@@ -2481,8 +2559,9 @@ void elf::hexagonTLSSymbolUpdate(ArrayRef<OutputSection *> outputSections) {
           for (Relocation &rel : isec->relocs())
             if (rel.sym->type == llvm::ELF::STT_TLS && rel.expr == R_PLT_PC) {
               if (needEntry) {
-                sym->allocateAux();
-                addPltEntry(*in.plt, *in.gotPlt, *in.relaPlt, target->pltRel,
+                Compartment &c = isec->getCompartment();
+                sym->allocateAux(c);
+                addPltEntry(*c.plt, *c.gotPlt, *c.relaPlt, target->pltRel,
                             *sym);
                 needEntry = false;
               }

--- a/lld/ELF/Relocations.h
+++ b/lld/ELF/Relocations.h
@@ -16,6 +16,7 @@
 
 namespace lld::elf {
 class Symbol;
+struct Compartment;
 class InputSection;
 class InputSectionBase;
 class OutputSection;
@@ -189,7 +190,7 @@ private:
   ThunkSection *addThunkSection(OutputSection *os, InputSectionDescription *,
                                 uint64_t off);
 
-  bool normalizeExistingThunk(Relocation &rel, uint64_t src);
+  bool normalizeExistingThunk(Compartment &c, Relocation &rel, uint64_t src);
 
   // Record all the available Thunks for a (Symbol, addend) pair, where Symbol
   // is represented as a (section, offset) pair. There may be multiple

--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -91,9 +91,9 @@ std::string lld::verboseToString(const Symbol *b, uint64_t symOffset) {
   else
     msg += "<unknown kind> ";
 
-  if (b->isInGot())
+  if (b->isInAnyGot())
     msg += "(in GOT) ";
-  if (b->isInPlt())
+  if (b->isInAnyPlt())
     msg += "(in PLT) ";
 
   const elf::Defined* dr = dyn_cast<elf::Defined>(b);
@@ -144,6 +144,8 @@ Defined *ElfSym::relaIpltStart;
 Defined *ElfSym::relaIpltEnd;
 Defined *ElfSym::tlsModuleBase;
 SmallVector<SymbolAux, 0> elf::symAux;
+SymbolCompartAux elf::defaultSymbolCompartAux;
+std::mutex elf::compartMutex;
 
 static uint64_t getSymVA(const Symbol &sym, int64_t addend) {
   switch (sym.kind()) {
@@ -197,7 +199,7 @@ static uint64_t getSymVA(const Symbol &sym, int64_t addend) {
     // field etc) do the same trick as compiler uses to mark microMIPS
     // for CPU - set the less-significant bit.
     if (config->emachine == EM_MIPS && isMicroMips() &&
-        ((sym.stOther & STO_MIPS_MICROMIPS) || sym.hasFlag(NEEDS_COPY)))
+        ((sym.stOther & STO_MIPS_MICROMIPS) || sym.needsCopyAny))
       va |= 1;
 
     if (d.isTls() && !config->relocatable) {
@@ -226,37 +228,55 @@ static uint64_t getSymVA(const Symbol &sym, int64_t addend) {
   llvm_unreachable("invalid symbol kind");
 }
 
+bool Symbol::isInAnyGot() const {
+  for (Compartment &c : compartments)
+    if (isInGot(c))
+      return true;
+  return false;
+}
+
+bool Symbol::isInAnyPlt() const {
+  for (Compartment &c : compartments)
+    if (isInPlt(c))
+      return true;
+  return false;
+}
+
 uint64_t Symbol::getVA(int64_t addend) const {
   return getSymVA(*this, addend) + addend;
 }
 
-uint64_t Symbol::getGotVA() const {
-  if (gotInIgot)
-    return in.igotPlt->getVA() + getGotPltOffset();
-  return in.got->getVA() + getGotOffset();
+uint64_t Symbol::getGotVA(const Compartment &c) const {
+  const SymbolCompartAux &aux = compartAux(c);
+  if (aux.gotInIgot)
+    return c.igotPlt->getVA() + getGotPltOffset(c);
+  return c.got->getVA() + getGotOffset(c);
 }
 
-uint64_t Symbol::getGotOffset() const {
-  return getGotIdx() * target->gotEntrySize;
+uint64_t Symbol::getGotOffset(const Compartment &c) const {
+  return getGotIdx(c) * target->gotEntrySize;
 }
 
-uint64_t Symbol::getGotPltVA() const {
-  if (isInIplt)
-    return in.igotPlt->getVA() + getGotPltOffset();
-  return in.gotPlt->getVA() + getGotPltOffset();
+uint64_t Symbol::getGotPltVA(const Compartment &c) const {
+  const SymbolCompartAux &aux = compartAux(c);
+  if (aux.isInIplt)
+    return c.igotPlt->getVA() + getGotPltOffset(c);
+  return c.gotPlt->getVA() + getGotPltOffset(c);
 }
 
-uint64_t Symbol::getGotPltOffset() const {
-  if (isInIplt)
-    return getPltIdx() * target->gotEntrySize;
-  return (getPltIdx() + target->gotPltHeaderEntriesNum) * target->gotEntrySize;
+uint64_t Symbol::getGotPltOffset(const Compartment &c) const {
+  const SymbolCompartAux &aux = compartAux(c);
+  if (aux.isInIplt)
+    return getPltIdx(c) * target->gotEntrySize;
+  return (getPltIdx(c) + target->gotPltHeaderEntriesNum) * target->gotEntrySize;
 }
 
-uint64_t Symbol::getPltVA() const {
-  uint64_t outVA = isInIplt
-                       ? in.iplt->getVA() + getPltIdx() * target->ipltEntrySize
-                       : in.plt->getVA() + in.plt->headerSize +
-                             getPltIdx() * target->pltEntrySize;
+uint64_t Symbol::getPltVA(const Compartment &c) const {
+  const SymbolCompartAux &aux = compartAux(c);
+  uint64_t outVA = aux.isInIplt
+                       ? c.iplt->getVA() + getPltIdx(c) * target->ipltEntrySize
+                       : c.plt->getVA() + c.plt->headerSize +
+                             getPltIdx(c) * target->pltEntrySize;
 
   // While linking microMIPS code PLT code are always microMIPS
   // code. Set the less-significant bit to track that fact.
@@ -266,13 +286,13 @@ uint64_t Symbol::getPltVA() const {
   return outVA;
 }
 
-uint64_t Symbol::getTgotVA() const {
+uint64_t Symbol::getTgotVA(const Compartment &c) const {
   // Like TLS symbols, the TGOT VA is the offset within the TGOT address space.
-  return in.tgot->getVA() + getTgotOffset() - Out::tgotPhdr->firstSec->addr;
+  return c.tgot->getVA() + getTgotOffset(c) - Out::tgotPhdr->firstSec->addr;
 }
 
-uint64_t Symbol::getTgotOffset() const {
-  return getTgotIdx() * target->gotEntrySize;
+uint64_t Symbol::getTgotOffset(const Compartment &c) const {
+  return getTgotIdx(c) * target->gotEntrySize;
 }
 
 uint64_t Symbol::getMipsCheriCapTableVA(const InputSectionBase *isec,
@@ -316,6 +336,13 @@ OutputSection *Symbol::getOutputSection() const {
       return sec->getOutputSection();
     return nullptr;
   }
+  return nullptr;
+}
+
+Compartment *Symbol::containingCompartment() const {
+  if (auto *s = dyn_cast<Defined>(this))
+    if (auto *sec = s->section)
+      return &sec->getCompartment();
   return nullptr;
 }
 

--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -657,6 +657,16 @@ bool Symbol::shouldReplace(const Defined &other) const {
   return !isGlobal() && other.isGlobal();
 }
 
+Symbol &elf::getCompartmentSymbol(const Compartment &c, Symbol &other) {
+  if (Defined *d = dyn_cast<Defined>(&other)) {
+    if (d->section && MergeInputSection::classof(d->section)) {
+      MergeInputSection *ms = cast<MergeInputSection>(d->section);
+      return ms->getCompartmentSymbol(c, other);
+    }
+  }
+  return other;
+}
+
 void elf::reportDuplicate(const Symbol &sym, const InputFile *newFile,
                           InputSectionBase *errSec, uint64_t errOffset) {
   if (config->allowMultipleDefinition)

--- a/lld/ELF/Symbols.h
+++ b/lld/ELF/Symbols.h
@@ -20,6 +20,7 @@
 #include "llvm/Object/ELF.h"
 #include "llvm/Support/Compiler.h"
 #include <tuple>
+#include <unordered_map>
 
 namespace lld {
 namespace elf {
@@ -31,6 +32,7 @@ std::string verboseToString(const elf::Symbol *b, uint64_t symOffset = 0);
 
 namespace elf {
 class CommonSymbol;
+struct Compartment;
 class Defined;
 class OutputSection;
 class SectionBase;
@@ -75,6 +77,54 @@ struct SymbolAux {
 };
 
 LLVM_LIBRARY_VISIBILITY extern SmallVector<SymbolAux, 0> symAux;
+
+// Per-compartment data stored for each symbol.  Since each compartment has a
+// separate GOTs, this holds fields related to GOT and PLT entries.
+struct SymbolCompartAux {
+  SymbolCompartAux() : isInIplt(false), gotInIgot(false) {}
+
+  SymbolCompartAux &operator=(const SymbolCompartAux &other) {
+    if (this != &other) {
+      flags.store(other.flags.load(std::memory_order_relaxed),
+                  std::memory_order_relaxed);
+      isInIplt = other.isInIplt;
+      gotInIgot = other.gotInIgot;
+      auxIdx = other.auxIdx;
+    }
+    return *this;
+  }
+
+  // Temporary flags used to communicate which symbol entries need PLT and GOT
+  // entries during postScanRelocations();
+  std::atomic<uint16_t> flags = 0;
+
+  // True if this symbol is in the Iplt sub-section of the Plt and the Igot
+  // sub-section of the .got.plt or .got.
+  uint8_t isInIplt : 1;
+
+  // True if this symbol needs a GOT entry and its GOT entry is actually in
+  // Igot. This will be true only for certain non-preemptible ifuncs.
+  uint8_t gotInIgot : 1;
+
+  // A symAux index used to access GOT/PLT entry indexes. This is allocated in
+  // postScanRelocations().
+  uint32_t auxIdx = 0;
+
+  void setFlags(uint16_t bits) {
+    flags.fetch_or(bits, std::memory_order_relaxed);
+  }
+  bool hasFlag(uint16_t bit) const {
+    assert(bit && (bit & (bit - 1)) == 0 && "bit must be a power of 2");
+    return flags.load(std::memory_order_relaxed) & bit;
+  }
+};
+
+typedef std::unordered_map<const Symbol *, std::unique_ptr<SymbolCompartAux>>
+    SymCompartMap;
+extern SymbolCompartAux defaultSymbolCompartAux;
+
+// XXX: This could be per-SymCompartMap
+extern std::mutex compartMutex;
 
 // The base class for real symbol classes.
 class Symbol {
@@ -211,6 +261,8 @@ public:
     nameSize = s.size();
   }
 
+  Compartment *containingCompartment() const;
+
   void parseSymbolVersion();
 
   // Get the NUL-terminated version suffix ("", "@...", or "@@...").
@@ -219,27 +271,55 @@ public:
   // truncated by Symbol::parseSymbolVersion().
   const char *getVersionSuffix() const { return nameData + nameSize; }
 
-  uint32_t getGotIdx() const { return symAux[auxIdx].gotIdx; }
-  uint32_t getPltIdx() const { return symAux[auxIdx].pltIdx; }
-  uint32_t getTlsDescIdx() const { return symAux[auxIdx].tlsDescIdx; }
-  uint32_t getTlsGdIdx() const { return symAux[auxIdx].tlsGdIdx; }
-  uint32_t getTgotIdx() const { return symAux[auxIdx].tgotIdx; }
-  uint32_t getTgotGotIdx() const { return symAux[auxIdx].tgotGotIdx; }
-  uint32_t getTgotTlsDescIdx() const { return symAux[auxIdx].tgotTlsDescIdx; }
-  uint32_t getTgotTlsGdIdx() const { return symAux[auxIdx].tgotTlsGdIdx; }
+  const SymbolCompartAux &compartAux(const Compartment &c) const;
 
-  bool isInGot() const { return getGotIdx() != uint32_t(-1); }
-  bool isInPlt() const { return getPltIdx() != uint32_t(-1); }
+  SymbolCompartAux &mutableCompartAux(Compartment &c);
+
+  uint32_t auxIdx(const Compartment &c) const { return compartAux(c).auxIdx; }
+
+  uint32_t getGotIdx(const Compartment &c) const {
+    return symAux[auxIdx(c)].gotIdx;
+  }
+  uint32_t getPltIdx(const Compartment &c) const {
+    return symAux[auxIdx(c)].pltIdx;
+  }
+  uint32_t getTlsDescIdx(const Compartment &c) const {
+    return symAux[auxIdx(c)].tlsDescIdx;
+  }
+  uint32_t getTlsGdIdx(const Compartment &c) const {
+    return symAux[auxIdx(c)].tlsGdIdx;
+  }
+  uint32_t getTgotIdx(const Compartment &c) const {
+    return symAux[auxIdx(c)].tgotIdx;
+  }
+  uint32_t getTgotGotIdx(const Compartment &c) const {
+    return symAux[auxIdx(c)].tgotGotIdx;
+  }
+  uint32_t getTgotTlsDescIdx(const Compartment &c) const {
+    return symAux[auxIdx(c)].tgotTlsDescIdx;
+  }
+  uint32_t getTgotTlsGdIdx(const Compartment &c) const {
+    return symAux[auxIdx(c)].tgotTlsGdIdx;
+  }
+
+  bool isInGot(const Compartment &c) const {
+    return getGotIdx(c) != uint32_t(-1);
+  }
+  bool isInPlt(const Compartment &c) const {
+    return getPltIdx(c) != uint32_t(-1);
+  }
+  bool isInAnyGot() const;
+  bool isInAnyPlt() const;
 
   uint64_t getVA(int64_t addend = 0) const;
 
-  uint64_t getGotOffset() const;
-  uint64_t getGotVA() const;
-  uint64_t getGotPltOffset() const;
-  uint64_t getGotPltVA() const;
-  uint64_t getPltVA() const;
-  uint64_t getTgotOffset() const;
-  uint64_t getTgotVA() const;
+  uint64_t getGotOffset(const Compartment &c) const;
+  uint64_t getGotVA(const Compartment &c) const;
+  uint64_t getGotPltOffset(const Compartment &c) const;
+  uint64_t getGotPltVA(const Compartment &c) const;
+  uint64_t getPltVA(const Compartment &c) const;
+  uint64_t getTgotOffset(const Compartment &c) const;
+  uint64_t getTgotVA(const Compartment &c) const;
   uint64_t getMipsCheriCapTableVA(const InputSectionBase *isec,
                                   uint64_t offset) const;
   uint64_t getMipsCheriCapTableOffset(const InputSectionBase *isec,
@@ -281,9 +361,9 @@ protected:
   Symbol(Kind k, InputFile *file, StringRef name, uint8_t binding,
          uint8_t stOther, uint8_t type)
       : file(file), nameData(name.data()), nameSize(name.size()), type(type),
-        binding(binding), stOther(stOther), symbolKind(k), 
-        usedByDynReloc(false), isSectionStartSymbol(false), 
-	exportDynamic(false) {}
+        binding(binding), stOther(stOther), symbolKind(k),
+        usedByDynReloc(false), isSectionStartSymbol(false),
+        exportDynamic(false), needsCopyAny(false) {}
 
   void overwrite(Symbol &sym, Kind k) const {
     if (sym.traced)
@@ -296,14 +376,6 @@ protected:
   }
 
 public:
-  // True if this symbol is in the Iplt sub-section of the Plt and the Igot
-  // sub-section of the .got.plt or .got.
-  uint8_t isInIplt : 1;
-
-  // True if this symbol needs a GOT entry and its GOT entry is actually in
-  // Igot. This will be true only for certain non-preemptible ifuncs.
-  uint8_t gotInIgot : 1;
-
   // True if defined relative to a section discarded by ICF.
   uint8_t folded : 1;
 
@@ -323,13 +395,9 @@ public:
   // True if targeted by a range extension thunk.
   uint8_t thunkAccessed : 1;
 
-  // Temporary flags used to communicate which symbol entries need PLT and GOT
-  // entries during postScanRelocations();
-  std::atomic<uint16_t> flags;
+  // True if any compartment needs a canonical PLT entry or a copy relocation.
+  std::atomic<bool> needsCopyAny;
 
-  // A symAux index used to access GOT/PLT entry indexes. This is allocated in
-  // postScanRelocations().
-  uint32_t auxIdx;
   uint32_t dynsymIndex;
 
   // This field is a index to the symbol's version definition.
@@ -338,23 +406,27 @@ public:
   // Version definition index.
   uint16_t versionId;
 
-  void setFlags(uint16_t bits) {
-    flags.fetch_or(bits, std::memory_order_relaxed);
+  void setFlags(Compartment &c, uint16_t bits) {
+    SymbolCompartAux &aux = mutableCompartAux(c);
+    aux.setFlags(bits);
   }
-  bool hasFlag(uint16_t bit) const {
+  bool hasFlag(const Compartment &c, uint16_t bit) const {
     assert(bit && (bit & (bit - 1)) == 0 && "bit must be a power of 2");
-    return flags.load(std::memory_order_relaxed) & bit;
+    const SymbolCompartAux &aux = compartAux(c);
+    return aux.hasFlag(bit);
   }
 
-  bool needsDynReloc() const {
-    return flags.load(std::memory_order_relaxed) &
+  bool needsDynReloc(const Compartment &c) const {
+    const SymbolCompartAux &aux = compartAux(c);
+    return aux.flags.load(std::memory_order_relaxed) &
            (NEEDS_COPY | NEEDS_GOT | NEEDS_PLT | NEEDS_TLSDESC | NEEDS_TLSGD |
             NEEDS_GOT_DTPREL | NEEDS_TLSIE | NEEDS_TGOT | NEEDS_TGOT_GOT |
             NEEDS_TGOT_TLSGD | NEEDS_TGOT_TLSDESC);
   }
-  void allocateAux() {
-    assert(auxIdx == 0);
-    auxIdx = symAux.size();
+  void allocateAux(Compartment &c) {
+    SymbolCompartAux &aux = mutableCompartAux(c);
+    assert(aux.auxIdx == 0);
+    aux.auxIdx = symAux.size();
     symAux.emplace_back();
   }
 

--- a/lld/ELF/Symbols.h
+++ b/lld/ELF/Symbols.h
@@ -664,6 +664,7 @@ template <typename... T> Defined *makeDefined(T &&...args) {
   return &s;
 }
 
+Symbol &getCompartmentSymbol(const Compartment &c, Symbol &other);
 void reportDuplicate(const Symbol &sym, const InputFile *newFile,
                      InputSectionBase *errSec, uint64_t errOffset);
 void maybeWarnUnorderableSymbol(const Symbol *sym);

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -398,8 +398,8 @@ CieRecord *EhFrameSection::addCie(EhSectionPiece &cie, ArrayRef<RelTy> rels) {
   Symbol *personality = nullptr;
   unsigned firstRelI = cie.firstRelocation;
   if (firstRelI != (unsigned)-1)
-    personality =
-        &cie.sec->template getFile<ELFT>()->getRelocTargetSym(rels[firstRelI]);
+    personality = &cie.sec->template getFile<ELFT>()->getRelocTargetSym(
+        getCompartment(), rels[firstRelI]);
 
   // Search for an existing CIE by CIE contents/relocation target pair.
   CieRecord *&rec = cieMap[{cie.data(), personality}];
@@ -429,7 +429,8 @@ Defined *EhFrameSection::isFdeLive(EhSectionPiece &fde, ArrayRef<RelTy> rels) {
     return nullptr;
 
   const RelTy &rel = rels[firstRelI];
-  Symbol &b = sec->template getFile<ELFT>()->getRelocTargetSym(rel);
+  Symbol &b =
+      sec->template getFile<ELFT>()->getRelocTargetSym(getCompartment(), rel);
 
   // FDEs for garbage-collected or merged-by-ICF sections, or sections in
   // another partition, are dead.

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -662,19 +662,19 @@ void GotSection::addEntry(Symbol &sym) {
   // TODO: Separate out TLS IE entries for CHERI so we can pack them more
   // efficiently rather than consuming a whole capability-sized slot for an
   // integer.
-  assert(sym.auxIdx == symAux.size() - 1);
+  assert(sym.auxIdx(getCompartment()) == symAux.size() - 1);
   symAux.back().gotIdx = numEntries++;
 }
 
 bool GotSection::addTlsDescEntry(Symbol &sym) {
-  assert(sym.auxIdx == symAux.size() - 1);
+  assert(sym.auxIdx(getCompartment()) == symAux.size() - 1);
   symAux.back().tlsDescIdx = numEntries;
   numEntries += 2;
   return true;
 }
 
 bool GotSection::addDynTlsEntry(Symbol &sym) {
-  assert(sym.auxIdx == symAux.size() - 1);
+  assert(sym.auxIdx(getCompartment()) == symAux.size() - 1);
   symAux.back().tlsGdIdx = numEntries;
   // Global Dynamic TLS entries take two GOT slots, except on CHERI where they
   // can be packed into one GOT slot.
@@ -686,18 +686,18 @@ bool GotSection::addDynTlsEntry(Symbol &sym) {
 }
 
 void GotSection::addTgotEntry(Symbol &sym) {
-  assert(sym.auxIdx == symAux.size() - 1);
+  assert(sym.auxIdx(getCompartment()) == symAux.size() - 1);
   symAux.back().tgotGotIdx = numEntries++;
 }
 
 void GotSection::addTgotTlsDescEntry(Symbol &sym) {
-  assert(sym.auxIdx == symAux.size() - 1);
+  assert(sym.auxIdx(getCompartment()) == symAux.size() - 1);
   symAux.back().tgotTlsDescIdx = numEntries;
   numEntries += 2;
 }
 
 bool GotSection::addTgotDynTlsEntry(Symbol &sym) {
-  assert(sym.auxIdx == symAux.size() - 1);
+  assert(sym.auxIdx(getCompartment()) == symAux.size() - 1);
   symAux.back().tgotTlsGdIdx = numEntries;
   // Global Dynamic TLS entries take two GOT slots, except on CHERI where they
   // can be packed into one GOT slot.
@@ -719,7 +719,7 @@ bool GotSection::addTlsIndex() {
 }
 
 uint32_t GotSection::getTlsDescOffset(const Symbol &sym) const {
-  return sym.getTlsDescIdx() * target->gotEntrySize;
+  return sym.getTlsDescIdx(getCompartment()) * target->gotEntrySize;
 }
 
 uint64_t GotSection::getTlsDescAddr(const Symbol &sym) const {
@@ -727,15 +727,15 @@ uint64_t GotSection::getTlsDescAddr(const Symbol &sym) const {
 }
 
 uint64_t GotSection::getGlobalDynAddr(const Symbol &b) const {
-  return this->getVA() + b.getTlsGdIdx() * target->gotEntrySize;
+  return this->getVA() + b.getTlsGdIdx(getCompartment()) * target->gotEntrySize;
 }
 
 uint64_t GotSection::getGlobalDynOffset(const Symbol &b) const {
-  return b.getTlsGdIdx() * target->gotEntrySize;
+  return b.getTlsGdIdx(getCompartment()) * target->gotEntrySize;
 }
 
 uint64_t GotSection::getTgotOffset(const Symbol &sym) const {
-  return sym.getTgotGotIdx() * target->gotEntrySize;
+  return sym.getTgotGotIdx(getCompartment()) * target->gotEntrySize;
 }
 
 uint64_t GotSection::getTgotAddr(const Symbol &sym) const {
@@ -743,7 +743,7 @@ uint64_t GotSection::getTgotAddr(const Symbol &sym) const {
 }
 
 uint64_t GotSection::getTgotTlsDescOffset(const Symbol &sym) const {
-  return sym.getTgotTlsDescIdx() * target->gotEntrySize;
+  return sym.getTgotTlsDescIdx(getCompartment()) * target->gotEntrySize;
 }
 
 uint64_t GotSection::getTgotTlsDescAddr(const Symbol &sym) const {
@@ -751,11 +751,12 @@ uint64_t GotSection::getTgotTlsDescAddr(const Symbol &sym) const {
 }
 
 uint64_t GotSection::getTgotGlobalDynAddr(const Symbol &b) const {
-  return this->getVA() + b.getTgotTlsGdIdx() * target->gotEntrySize;
+  return this->getVA() +
+         b.getTgotTlsGdIdx(getCompartment()) * target->gotEntrySize;
 }
 
 uint64_t GotSection::getTgotGlobalDynOffset(const Symbol &b) const {
-  return b.getTgotTlsGdIdx() * target->gotEntrySize;
+  return b.getTgotTlsGdIdx(getCompartment()) * target->gotEntrySize;
 }
 
 void GotSection::finalizeContents() {
@@ -940,6 +941,7 @@ void MipsGotSection::build() {
     return;
 
   std::vector<FileGot> mergedGots(1);
+  Compartment &c = getCompartment();
 
   // For each GOT move non-preemptible symbols from the `Global`
   // to `Local16` list. Preemptible symbol might become non-preemptible
@@ -1055,13 +1057,13 @@ void MipsGotSection::build() {
   // Update SymbolAux::gotIdx field to use this
   // value later in the `sortMipsSymbols` function.
   for (auto &p : primGot->global) {
-    if (p.first->auxIdx == 0)
-      p.first->allocateAux();
+    if (p.first->auxIdx(c) == 0)
+      p.first->allocateAux(c);
     symAux.back().gotIdx = p.second;
   }
   for (auto &p : primGot->relocs) {
-    if (p.first->auxIdx == 0)
-      p.first->allocateAux();
+    if (p.first->auxIdx(c) == 0)
+      p.first->allocateAux(c);
     symAux.back().gotIdx = p.second;
   }
 
@@ -1231,7 +1233,7 @@ GotPltSection::GotPltSection()
 }
 
 void GotPltSection::addEntry(Symbol &sym) {
-  assert(sym.auxIdx == symAux.size() - 1 &&
+  assert(sym.auxIdx(getCompartment()) == symAux.size() - 1 &&
          symAux.back().pltIdx == entries.size());
   entries.push_back(&sym);
 }
@@ -1242,10 +1244,11 @@ size_t GotPltSection::getSize() const {
 }
 
 void GotPltSection::writeTo(uint8_t *buf) {
+  Compartment &c = getCompartment();
   target->writeGotPltHeader(buf);
   buf += target->gotPltHeaderEntriesNum * target->gotEntrySize;
   for (const Symbol *b : entries) {
-    target->writeGotPlt(buf, *b);
+    target->writeGotPlt(c, buf, *b);
     buf += target->gotEntrySize;
   }
 }
@@ -1298,7 +1301,7 @@ TgotSection::TgotSection()
 
 void TgotSection::addConstant(const Relocation &r) { relocations.push_back(r); }
 void TgotSection::addEntry(Symbol &sym) {
-  assert(sym.auxIdx == symAux.size() - 1);
+  assert(sym.auxIdx(getCompartment()) == symAux.size() - 1);
   symAux.back().tgotIdx = numEntries++;
 }
 
@@ -1376,8 +1379,9 @@ static uint64_t addRelaSz(const RelocationBaseSection &relaDyn) {
   size_t size = relaDyn.getSize();
   if (in.relaIplt->getParent() == relaDyn.getParent())
     size += in.relaIplt->getSize();
-  if (in.relaPlt->getParent() == relaDyn.getParent())
-    size += in.relaPlt->getSize();
+  for (const Compartment &c : compartments)
+    if (c.relaPlt->getParent() == relaDyn.getParent())
+      size += c.relaPlt->getSize();
   return size;
 }
 
@@ -1385,10 +1389,10 @@ static uint64_t addRelaSz(const RelocationBaseSection &relaDyn) {
 // output section. When this occurs we cannot just use the OutputSection
 // Size. Moreover the [DT_JMPREL, DT_JMPREL + DT_PLTRELSZ) is permitted to
 // overlap with the [DT_RELA, DT_RELA + DT_RELASZ).
-static uint64_t addPltRelSz() {
-  size_t size = in.relaPlt->getSize();
-  if (in.relaIplt->getParent() == in.relaPlt->getParent() &&
-      in.relaIplt->name == in.relaPlt->name)
+static uint64_t addPltRelSz(const Compartment &c) {
+  size_t size = c.relaPlt->getSize();
+  if (in.relaIplt->getParent() == c.relaPlt->getParent() &&
+      in.relaIplt->name == c.relaPlt->name)
     size += in.relaIplt->getSize();
   return size;
 }
@@ -1513,36 +1517,50 @@ DynamicSection<ELFT>::computeContents() {
   // as relaIplt has. And we still want to emit proper dynamic tags for that
   // case, so here we always use relaPlt as marker for the beginning of
   // .rel[a].plt section.
-  if (isMain && (in.relaPlt->isNeeded() || in.relaIplt->isNeeded())) {
-    addInSec(DT_JMPREL, *in.relaPlt);
-    entries.emplace_back(DT_PLTRELSZ, addPltRelSz());
+  bool pltrel = false, aarch64_variant_pcs = false, riscv_variant_cc = false;
+  auto addPlt = [&](const Compartment &c) {
+    if (!c.relaPlt->isNeeded() && (!c.isDefault() || !in.relaIplt->isNeeded()))
+      return;
+    addInSec(DT_JMPREL, *c.relaPlt);
+    addInt(DT_PLTRELSZ, addPltRelSz(c));
     switch (config->emachine) {
     case EM_MIPS:
-      addInSec(DT_MIPS_PLTGOT, *in.gotPlt);
+      addInSec(DT_MIPS_PLTGOT, *c.gotPlt);
       break;
     case EM_SPARCV9:
-      addInSec(DT_PLTGOT, *in.plt);
+      addInSec(DT_PLTGOT, *c.plt);
       break;
     case EM_AARCH64:
-      if (llvm::find_if(in.relaPlt->relocs, [](const DynamicReloc &r) {
-           return r.type == target->pltRel &&
-                  r.sym->stOther & STO_AARCH64_VARIANT_PCS;
-          }) != in.relaPlt->relocs.end())
-        addInt(DT_AARCH64_VARIANT_PCS, 0);
-      addInSec(DT_PLTGOT, *in.gotPlt);
+      if (llvm::find_if(c.relaPlt->relocs, [](const DynamicReloc &r) {
+            return r.type == target->pltRel &&
+                   r.sym->stOther & STO_AARCH64_VARIANT_PCS;
+          }) != c.relaPlt->relocs.end())
+        aarch64_variant_pcs = true;
+      addInSec(DT_PLTGOT, *c.gotPlt);
       break;
     case EM_RISCV:
-      if (llvm::any_of(in.relaPlt->relocs, [](const DynamicReloc &r) {
+      if (llvm::any_of(c.relaPlt->relocs, [](const DynamicReloc &r) {
             return r.type == target->pltRel &&
                    (r.sym->stOther & STO_RISCV_VARIANT_CC);
           }))
-        addInt(DT_RISCV_VARIANT_CC, 0);
+        riscv_variant_cc = true;
       [[fallthrough]];
     default:
-      addInSec(DT_PLTGOT, *in.gotPlt);
+      addInSec(DT_PLTGOT, *c.gotPlt);
       break;
     }
-    addInt(DT_PLTREL, config->isRela ? DT_RELA : DT_REL);
+    pltrel = true;
+  };
+
+  if (isMain) {
+    for (const Compartment &c : compartments)
+      addPlt(c);
+    if (aarch64_variant_pcs)
+      addInt(DT_AARCH64_VARIANT_PCS, 0);
+    if (riscv_variant_cc)
+      addInt(DT_RISCV_VARIANT_CC, 0);
+    if (pltrel)
+      addInt(DT_PLTREL, config->isRela ? DT_RELA : DT_REL);
   }
 
   if (isMain && in.relaTgot->isNeeded()) {
@@ -1574,6 +1592,10 @@ DynamicSection<ELFT>::computeContents() {
     addInSec(DT_GNU_HASH, *part.gnuHashTab);
   if (part.hashTab && part.hashTab->getParent())
     addInSec(DT_HASH, *part.hashTab);
+  if (in.compartStrTab) {
+    addInSec(DT_C18N_STRTAB, *in.compartStrTab);
+    addInt(DT_C18N_STRTABSZ, in.compartStrTab->getSize());
+  }
 
   if (isMain) {
     if (Out::preinitArray) {
@@ -1682,13 +1704,14 @@ DynamicSection<ELFT>::computeContents() {
   // DT_PPC_GOT indicates to glibc Secure PLT is used. If DT_PPC_GOT is absent,
   // glibc assumes the old-style BSS PLT layout which we don't support.
   if (config->emachine == EM_PPC)
-    addInSec(DT_PPC_GOT, *in.got);
+    addInSec(DT_PPC_GOT, *defaultCompart->got);
 
   // Glink dynamic tag is required by the V2 abi if the plt section isn't empty.
-  if (config->emachine == EM_PPC64 && in.plt->isNeeded()) {
+  if (config->emachine == EM_PPC64 && defaultCompart->plt->isNeeded()) {
     // The Glink tag points to 32 bytes before the first lazy symbol resolution
     // stub, which starts directly after the header.
-    addInt(DT_PPC64_GLINK, in.plt->getVA() + target->pltHeaderSize - 32);
+    addInt(DT_PPC64_GLINK,
+           defaultCompart->plt->getVA() + target->pltHeaderSize - 32);
   }
 
   if (config->emachine == EM_PPC64)
@@ -1818,6 +1841,7 @@ void RelocationBaseSection::partitionRels() {
 
 void RelocationBaseSection::finalizeContents() {
   SymbolTableBaseSection *symTab = getPartition().dynSymTab.get();
+  Compartment &c = getCompartment();
 
   // When linking glibc statically, .rel{,a}.plt contains R_*_IRELATIVE
   // relocations due to IFUNC (e.g. strcpy). sh_link will be set to 0 in that
@@ -1827,7 +1851,7 @@ void RelocationBaseSection::finalizeContents() {
   else
     getParent()->link = 0;
 
-  if (in.relaPlt.get() == this && in.gotPlt->getParent()) {
+  if (c.relaPlt.get() == this && c.gotPlt->getParent()) {
     getParent()->flags |= ELF::SHF_INFO_LINK;
     // For CheriABI we use the captable as the sh_info value
     if (config->isCheriAbi && in.mipsCheriCapTable &&
@@ -1835,23 +1859,49 @@ void RelocationBaseSection::finalizeContents() {
       assert(in.mipsCheriCapTable->getParent()->sectionIndex != UINT32_MAX);
       getParent()->info = in.mipsCheriCapTable->getParent()->sectionIndex;
     } else {
-      getParent()->info = in.gotPlt->getParent()->sectionIndex;
+      getParent()->info = c.gotPlt->getParent()->sectionIndex;
     }
   }
-  if (in.relaIplt.get() == this && in.igotPlt->getParent()) {
-    getParent()->flags |= ELF::SHF_INFO_LINK;
-    // For CheriABI we use the captable as the sh_info value
-    if (config->isCheriAbi && in.mipsCheriCapTable &&
-        in.mipsCheriCapTable->isNeeded()) {
-      assert(in.mipsCheriCapTable->getParent()->sectionIndex != UINT32_MAX);
-      getParent()->info = in.mipsCheriCapTable->getParent()->sectionIndex;
-    } else {
-      getParent()->info = in.igotPlt->getParent()->sectionIndex;
+  if (in.relaIplt.get() == this) {
+    // Only add a link if there is exactly one Iplt section.
+    IgotPltSection *igotPlt = nullptr;
+    for (const Compartment &c : compartments) {
+      if (!c.igotPlt->isNeeded())
+        continue;
+      if (igotPlt != nullptr) {
+        igotPlt = nullptr;
+        break;
+      }
+      igotPlt = c.igotPlt.get();
+    }
+    if (igotPlt && igotPlt->getParent()) {
+      getParent()->flags |= ELF::SHF_INFO_LINK;
+      // For CheriABI we use the captable as the sh_info value
+      if (config->isCheriAbi && in.mipsCheriCapTable &&
+          in.mipsCheriCapTable->isNeeded()) {
+        assert(in.mipsCheriCapTable->getParent()->sectionIndex != UINT32_MAX);
+        getParent()->info = in.mipsCheriCapTable->getParent()->sectionIndex;
+      } else {
+        getParent()->info = igotPlt->getParent()->sectionIndex;
+      }
     }
   }
-  if (in.relaTgot.get() == this && in.tgot->getParent()) {
-    getParent()->flags |= ELF::SHF_INFO_LINK;
-    getParent()->info = in.tgot->getParent()->sectionIndex;
+  if (in.relaTgot.get() == this) {
+    // Only add a link if there is exactly one Tgot section.
+    TgotSection *tgot = nullptr;
+    for (const Compartment &c : compartments) {
+      if (!c.tgot->isNeeded())
+        continue;
+      if (tgot != nullptr) {
+        tgot = nullptr;
+        break;
+      }
+      tgot = c.tgot.get();
+    }
+    if (tgot && tgot->getParent()) {
+      getParent()->flags |= ELF::SHF_INFO_LINK;
+      getParent()->info = tgot->getParent()->sectionIndex;
+    }
   }
   for (auto reloc : relocs) {
     if (config->isCheriAbi && reloc.inputSec->name == "__cap_relocs") {
@@ -2281,13 +2331,16 @@ SymbolTableBaseSection::SymbolTableBaseSection(StringTableSection &strTabSec)
 // ftp://www.linux-mips.org/pub/linux/mips/doc/ABI/mipsabi.pdf
 static bool sortMipsSymbols(const SymbolTableEntry &l,
                             const SymbolTableEntry &r) {
+  // XXXJHB: Assume a single compartment for MIPS.
+  Compartment &c = *defaultCompart;
+
   // Sort entries related to non-local preemptible symbols by GOT indexes.
   // All other entries go to the beginning of a dynsym in arbitrary order.
-  if (l.sym->isInGot() && r.sym->isInGot())
-    return l.sym->getGotIdx() < r.sym->getGotIdx();
-  if (!l.sym->isInGot() && !r.sym->isInGot())
+  if (l.sym->isInGot(c) && r.sym->isInGot(c))
+    return l.sym->getGotIdx(c) < r.sym->getGotIdx(c);
+  if (!l.sym->isInGot(c) && !r.sym->isInGot(c))
     return false;
-  return !l.sym->isInGot();
+  return !l.sym->isInGot(c);
 }
 
 void SymbolTableBaseSection::finalizeContents() {
@@ -2402,8 +2455,8 @@ static BssSection *getCommonSec(Symbol *sym) {
 }
 
 static uint32_t getSymSectionIndex(Symbol *sym) {
-  assert(!(sym->hasFlag(NEEDS_COPY) && sym->isObject()));
-  if (!isa<Defined>(sym) || sym->hasFlag(NEEDS_COPY))
+  assert(!(sym->needsCopyAny && sym->isObject()));
+  if (!isa<Defined>(sym) || sym->needsCopyAny)
     return SHN_UNDEF;
   if (const OutputSection *os = sym->getOutputSection())
     return os->sectionIndex >= SHN_LORESERVE ? (uint32_t)SHN_XINDEX
@@ -2463,7 +2516,7 @@ template <class ELFT> void SymbolTableSection<ELFT>::writeTo(uint8_t *buf) {
 
     for (SymbolTableEntry &ent : symbols) {
       Symbol *sym = ent.sym;
-      if (sym->isInPlt() && sym->hasFlag(NEEDS_COPY))
+      if (sym->isInAnyPlt() && sym->needsCopyAny)
         eSym->st_other |= STO_MIPS_PLT;
       if (isMicroMips()) {
         // We already set the less-significant bit for symbols
@@ -2474,7 +2527,7 @@ template <class ELFT> void SymbolTableSection<ELFT>::writeTo(uint8_t *buf) {
         // like `objdump` will be able to deal with a correct
         // symbol position.
         if (sym->isDefined() &&
-            ((sym->stOther & STO_MIPS_MICROMIPS) || sym->hasFlag(NEEDS_COPY))) {
+            ((sym->stOther & STO_MIPS_MICROMIPS) || sym->needsCopyAny)) {
           if (!strTabSec.isDynamic())
             eSym->st_value &= ~1;
           eSym->st_other |= STO_MIPS_MICROMIPS;
@@ -2728,19 +2781,20 @@ PltSection::PltSection()
 }
 
 void PltSection::writeTo(uint8_t *buf) {
+  Compartment &c = getCompartment();
   // At beginning of PLT, we have code to call the dynamic
   // linker to resolve dynsyms at runtime. Write such code.
-  target->writePltHeader(buf);
+  target->writePltHeader(c, buf);
   size_t off = headerSize;
 
   for (const Symbol *sym : entries) {
-    target->writePlt(buf + off, *sym, getVA() + off);
+    target->writePlt(c, buf + off, *sym, getVA() + off);
     off += target->pltEntrySize;
   }
 }
 
 void PltSection::addEntry(Symbol &sym) {
-  assert(sym.auxIdx == symAux.size() - 1);
+  assert(sym.auxIdx(getCompartment()) == symAux.size() - 1);
   symAux.back().pltIdx = entries.size();
   entries.push_back(&sym);
 }
@@ -2751,7 +2805,8 @@ size_t PltSection::getSize() const {
 
 bool PltSection::isNeeded() const {
   // For -z retpolineplt, .iplt needs the .plt header.
-  return !entries.empty() || (config->zRetpolineplt && in.iplt->isNeeded());
+  return !entries.empty() ||
+         (config->zRetpolineplt && getCompartment().iplt->isNeeded());
 }
 
 // Used by ARM to add mapping symbols in the PLT section, which aid
@@ -2775,9 +2830,10 @@ IpltSection::IpltSection()
 }
 
 void IpltSection::writeTo(uint8_t *buf) {
+  Compartment &c = getCompartment();
   uint32_t off = 0;
   for (const Symbol *sym : entries) {
-    target->writeIplt(buf + off, *sym, getVA() + off);
+    target->writeIplt(c, buf + off, *sym, getVA() + off);
     off += target->ipltEntrySize;
   }
 }
@@ -2787,7 +2843,7 @@ size_t IpltSection::getSize() const {
 }
 
 void IpltSection::addEntry(Symbol &sym) {
-  assert(sym.auxIdx == symAux.size() - 1);
+  assert(sym.auxIdx(getCompartment()) == symAux.size() - 1);
   symAux.back().pltIdx = entries.size();
   entries.push_back(&sym);
 }
@@ -2807,7 +2863,7 @@ PPC32GlinkSection::PPC32GlinkSection() {
 }
 
 void PPC32GlinkSection::writeTo(uint8_t *buf) {
-  writePPC32GlinkSection(buf, entries.size());
+  writePPC32GlinkSection(getCompartment(), buf, entries.size());
 }
 
 size_t PPC32GlinkSection::getSize() const {
@@ -2876,15 +2932,18 @@ IBTPltSection::IBTPltSection()
     : SyntheticSection(SHF_ALLOC | SHF_EXECINSTR, SHT_PROGBITS, 16, ".plt") {}
 
 void IBTPltSection::writeTo(uint8_t *buf) {
-  target->writeIBTPlt(buf, in.plt->getNumEntries());
+  Compartment &c = getCompartment();
+  target->writeIBTPlt(c, buf, c.plt->getNumEntries());
 }
 
 size_t IBTPltSection::getSize() const {
   // 16 is the header size of .plt.
-  return 16 + in.plt->getNumEntries() * target->pltEntrySize;
+  return 16 + getCompartment().plt->getNumEntries() * target->pltEntrySize;
 }
 
-bool IBTPltSection::isNeeded() const { return in.plt->getNumEntries() > 0; }
+bool IBTPltSection::isNeeded() const {
+  return getCompartment().plt->getNumEntries() > 0;
+}
 
 // The string hash function for .gdb_index.
 static uint32_t computeGdbHash(StringRef s) {
@@ -3789,6 +3848,7 @@ ThunkSection::ThunkSection(OutputSection *os, uint64_t off)
     : SyntheticSection(SHF_ALLOC | SHF_EXECINSTR, SHT_PROGBITS,
                        config->emachine == EM_PPC64 ? 16 : 4, ".text.thunk") {
   this->parent = os;
+  this->compartment = os->compartment;
   this->outSecOff = off;
 }
 
@@ -4043,12 +4103,8 @@ void InStruct::reset() {
   riscvAttributes.reset();
   bss.reset();
   bssRelRo.reset();
-  got.reset();
-  gotPlt.reset();
-  igotPlt.reset();
-  tgot.reset();
+  compartStrTab.reset();
   mipsCheriCapTable.reset();
-  pccPadding.reset();
   mipsCheriCapTableMapping.reset();
   armCmseSGSection.reset();
   ppc64LongBranchTarget.reset();
@@ -4059,11 +4115,8 @@ void InStruct::reset() {
   mipsRldMap.reset();
   partEnd.reset();
   partIndex.reset();
-  plt.reset();
-  iplt.reset();
   ppc32Got2.reset();
   ibtPlt.reset();
-  relaPlt.reset();
   relaIplt.reset();
   relaTgot.reset();
   tgotCapRelocs.reset();
@@ -4071,7 +4124,6 @@ void InStruct::reset() {
   strTab.reset();
   symTab.reset();
   symTabShndx.reset();
-  cheriBounds = nullptr;
 }
 
 constexpr char kMemtagAndroidNoteName[] = "Android";
@@ -4119,6 +4171,9 @@ size_t PackageMetadataNote::getSize() const {
 }
 
 InStruct elf::in;
+
+std::vector<Compartment> elf::compartments;
+Compartment *elf::defaultCompart;
 
 std::vector<Partition> elf::partitions;
 Partition *elf::mainPart;

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -1347,6 +1347,11 @@ inline Partition &SectionBase::getPartition() const {
   return partitions[partition - 1];
 }
 
+inline Compartment &SectionBase::getCompartment() const {
+  // XXX: Should this work? assert(isLive());
+  return compartments[compartment];
+}
+
 // Linker generated sections which can be used as inputs and are not specific to
 // a partition.
 struct InStruct {
@@ -1354,12 +1359,8 @@ struct InStruct {
   std::unique_ptr<SyntheticSection> riscvAttributes;
   std::unique_ptr<BssSection> bss;
   std::unique_ptr<BssSection> bssRelRo;
-  std::unique_ptr<GotSection> got;
-  std::unique_ptr<GotPltSection> gotPlt;
-  std::unique_ptr<IgotPltSection> igotPlt;
-  std::unique_ptr<TgotSection> tgot;
+  std::unique_ptr<StringTableSection> compartStrTab;
   std::unique_ptr<MipsCheriCapTableSection> mipsCheriCapTable;
-  std::unique_ptr<CheriPccPaddingSection> pccPadding;
   // For per-file/per-function tables:
   std::unique_ptr<MipsCheriCapTableMappingSection> mipsCheriCapTableMapping;
   std::unique_ptr<SyntheticSection> armCmseSGSection;
@@ -1371,11 +1372,8 @@ struct InStruct {
   std::unique_ptr<MipsRldMapSection> mipsRldMap;
   std::unique_ptr<SyntheticSection> partEnd;
   std::unique_ptr<SyntheticSection> partIndex;
-  std::unique_ptr<PltSection> plt;
-  std::unique_ptr<IpltSection> iplt;
   std::unique_ptr<PPC32Got2Section> ppc32Got2;
   std::unique_ptr<IBTPltSection> ibtPlt;
-  std::unique_ptr<RelocationBaseSection> relaPlt;
   std::unique_ptr<RelocationBaseSection> relaIplt;
   std::unique_ptr<RelocationBaseSection> relaTgot;
   std::unique_ptr<CheriCapRelocsSection> tgotCapRelocs;
@@ -1384,12 +1382,56 @@ struct InStruct {
   std::unique_ptr<SymbolTableBaseSection> symTab;
   std::unique_ptr<SymtabShndxSection> symTabShndx;
 
-  PhdrEntry *cheriBounds;
-
   void reset();
 };
 
 LLVM_LIBRARY_VISIBILITY extern InStruct in;
+
+struct Compartment {
+  StringRef name;
+  unsigned nameIndex;
+
+  std::string suffix;
+
+  SymCompartMap symCompartMap;
+
+  // Synthetic sections
+  std::unique_ptr<GotSection> got;
+  std::unique_ptr<GotPltSection> gotPlt;
+  std::unique_ptr<IgotPltSection> igotPlt;
+  std::unique_ptr<TgotSection> tgot;
+  std::unique_ptr<CheriPccPaddingSection> pccPadding;
+  std::unique_ptr<PltSection> plt;
+  std::unique_ptr<IpltSection> iplt;
+  std::unique_ptr<RelocationBaseSection> relaPlt;
+
+  SmallVector<PhdrEntry *, 1> phdrs;
+  PhdrEntry *relRo;
+  PhdrEntry *cheriBounds;
+
+  unsigned getNumber() const { return this - &compartments[0]; }
+  bool isDefault() const { return this == &compartments[0]; }
+};
+
+inline const SymbolCompartAux &Symbol::compartAux(const Compartment &c) const {
+  // Could be a shared lock if lock_guard worked for such things
+  std::lock_guard<std::mutex> lock(compartMutex);
+  const SymCompartMap &map = c.symCompartMap;
+  auto it = map.find(this);
+  return it == map.end() ? defaultSymbolCompartAux : *it->second.get();
+}
+
+inline SymbolCompartAux &Symbol::mutableCompartAux(Compartment &c) {
+  // XXX: This should possibly by an assertion to require the caller
+  // to hold the lock so that it also protects the caller's operations
+  // on the compartAux, but C++ people don't believe in lock assertions,
+  // so just write lock while adding the new entry to the table and
+  // let the caller (not) deal with the races.
+  std::lock_guard<std::mutex> lock(compartMutex);
+  SymCompartMap &map = c.symCompartMap;
+  auto p = map.emplace(this, std::make_unique<SymbolCompartAux>());
+  return *p.first->second.get();
+}
 
 } // namespace lld::elf
 

--- a/lld/ELF/Target.cpp
+++ b/lld/ELF/Target.cpp
@@ -147,8 +147,8 @@ int64_t TargetInfo::getImplicitAddend(const uint8_t *buf, RelType type) const {
 bool TargetInfo::usesOnlyLowPageBits(RelType type) const { return false; }
 
 bool TargetInfo::needsThunk(RelExpr expr, RelType type, const InputFile *file,
-                            uint64_t branchAddr, const Symbol &s,
-                            int64_t a) const {
+                            const Compartment &c, uint64_t branchAddr,
+                            const Symbol &s, int64_t a) const {
   return false;
 }
 
@@ -191,4 +191,8 @@ uint64_t TargetInfo::getImageBase() const {
   if (config->imageBase)
     return *config->imageBase;
   return config->isPic ? 0 : defaultImageBase;
+}
+void lld::elf::TargetInfo::relocateNoSym(uint8_t *loc, RelType type,
+                                         uint64_t val) const {
+  relocate(loc, Relocation{R_NONE, type, 0, 0, nullptr}, val);
 }

--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -36,7 +36,8 @@ public:
   virtual RelType getDynRel(RelType type) const { return 0; }
   virtual void writeGotPltHeader(uint8_t *buf) const {}
   virtual void writeGotHeader(uint8_t *buf) const {}
-  virtual void writeGotPlt(uint8_t *buf, const Symbol &s) const {};
+  virtual void writeGotPlt(Compartment &c, uint8_t *buf,
+                           const Symbol &s) const {};
   virtual void writeIgotPlt(uint8_t *buf, const Symbol &s) const {}
   virtual int64_t getImplicitAddend(const uint8_t *buf, RelType type) const;
   virtual int getTlsGdRelaxSkip(RelType type) const { return 1; }
@@ -44,16 +45,17 @@ public:
   // If lazy binding is supported, the first entry of the PLT has code
   // to call the dynamic linker to resolve PLT entries the first time
   // they are called. This function writes that code.
-  virtual void writePltHeader(uint8_t *buf) const {}
+  virtual void writePltHeader(Compartment &c, uint8_t *buf) const {}
 
-  virtual void writePlt(uint8_t *buf, const Symbol &sym,
+  virtual void writePlt(Compartment &c, uint8_t *buf, const Symbol &sym,
                         uint64_t pltEntryAddr) const {}
-  virtual void writeIplt(uint8_t *buf, const Symbol &sym,
+  virtual void writeIplt(Compartment &c, uint8_t *buf, const Symbol &sym,
                          uint64_t pltEntryAddr) const {
     // All but PPC32 and PPC64 use the same format for .plt and .iplt entries.
-    writePlt(buf, sym, pltEntryAddr);
+    writePlt(c, buf, sym, pltEntryAddr);
   }
-  virtual void writeIBTPlt(uint8_t *buf, size_t numEntries) const {}
+  virtual void writeIBTPlt(Compartment &c, uint8_t *buf,
+                           size_t numEntries) const {}
   virtual void addPltHeaderSymbols(InputSection &isec) const {}
   virtual void addPltSymbols(InputSection &isec, uint64_t off) const {}
 
@@ -67,8 +69,9 @@ public:
   // Decide whether a Thunk is needed for the relocation from File
   // targeting S.
   virtual bool needsThunk(RelExpr expr, RelType relocType,
-                          const InputFile *file, uint64_t branchAddr,
-                          const Symbol &s, int64_t a) const;
+                          const InputFile *file, const Compartment &c,
+                          uint64_t branchAddr, const Symbol &s,
+                          int64_t a) const;
 
   // On systems with range extensions we place collections of Thunks at
   // regular spacings that enable the majority of branches reach the Thunks.
@@ -89,9 +92,7 @@ public:
 
   virtual void relocate(uint8_t *loc, const Relocation &rel,
                         uint64_t val) const = 0;
-  void relocateNoSym(uint8_t *loc, RelType type, uint64_t val) const {
-    relocate(loc, Relocation{R_NONE, type, 0, 0, nullptr}, val);
-  }
+  void relocateNoSym(uint8_t *loc, RelType type, uint64_t val) const;
   virtual void relocateAlloc(InputSectionBase &sec, uint8_t *buf) const;
 
   // Do a linker relaxation pass and return true if we changed something.
@@ -215,7 +216,7 @@ static inline std::string getErrorLocation(const uint8_t *loc) {
 
 void processArmCmseSymbols();
 
-void writePPC32GlinkSection(uint8_t *buf, size_t numEntries);
+void writePPC32GlinkSection(Compartment &c, uint8_t *buf, size_t numEntries);
 
 unsigned getPPCDFormOp(unsigned secondaryOp);
 

--- a/lld/ELF/Thunks.cpp
+++ b/lld/ELF/Thunks.cpp
@@ -506,15 +506,17 @@ void Thunk::setOffset(uint64_t newOffset) {
 }
 
 // AArch64 Thunk base class.
-static uint64_t getAArch64ThunkDestVA(const Symbol &s, int64_t a) {
-  uint64_t v = s.isInPlt() ? s.getPltVA() : s.getVA(a);
+static uint64_t getAArch64ThunkDestVA(const Compartment &c, const Symbol &s,
+                                      int64_t a) {
+  uint64_t v = s.isInPlt(c) ? s.getPltVA(c) : s.getVA(a);
   return v;
 }
 
 bool AArch64Thunk::getMayUseShortThunk() {
   if (!mayUseShortThunk)
     return false;
-  uint64_t s = getAArch64ThunkDestVA(destination, addend);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getAArch64ThunkDestVA(c, destination, addend);
   uint64_t p = getThunkTargetSym()->getVA();
   mayUseShortThunk = llvm::isInt<28>(s - p);
   return mayUseShortThunk;
@@ -525,7 +527,8 @@ void AArch64Thunk::writeTo(uint8_t *buf) {
     writeLong(buf);
     return;
   }
-  uint64_t s = getAArch64ThunkDestVA(destination, addend);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getAArch64ThunkDestVA(c, destination, addend);
   uint64_t p = getThunkTargetSym()->getVA();
   write32(buf, 0x14000000); // b S
   target->relocateNoSym(buf, R_AARCH64_CALL26, s - p);
@@ -539,7 +542,8 @@ void AArch64ABSLongThunk::writeLong(uint8_t *buf) {
     0x00, 0x00, 0x00, 0x00, // L0: .xword S
     0x00, 0x00, 0x00, 0x00,
   };
-  uint64_t s = getAArch64ThunkDestVA(destination, addend);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getAArch64ThunkDestVA(c, destination, addend);
   memcpy(buf, data, sizeof(data));
   target->relocateNoSym(buf + 8, R_AARCH64_ABS64, s);
 }
@@ -563,7 +567,8 @@ void AArch64ADRPThunk::writeLong(uint8_t *buf) {
       0x10, 0x02, 0x00, 0x91, // add  x16, x16, R_AARCH64_ADD_ABS_LO12_NC(Dest)
       0x00, 0x02, 0x1f, 0xd6, // br   x16
   };
-  uint64_t s = getAArch64ThunkDestVA(destination, addend);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getAArch64ThunkDestVA(c, destination, addend);
   uint64_t p = getThunkTargetSym()->getVA();
   memcpy(buf, data, sizeof(data));
   target->relocateNoSym(buf, R_AARCH64_ADR_PREL_PG_HI21,
@@ -578,8 +583,8 @@ void AArch64ADRPThunk::addSymbols(ThunkSection &isec) {
 }
 
 // ARM Target Thunks
-static uint64_t getARMThunkDestVA(const Symbol &s) {
-  uint64_t v = s.isInPlt() ? s.getPltVA() : s.getVA();
+static uint64_t getARMThunkDestVA(const Compartment &c, const Symbol &s) {
+  uint64_t v = s.isInPlt(c) ? s.getPltVA(c) : s.getVA();
   return SignExtend64<32>(v);
 }
 
@@ -588,7 +593,8 @@ static uint64_t getARMThunkDestVA(const Symbol &s) {
 bool ARMThunk::getMayUseShortThunk() {
   if (!mayUseShortThunk)
     return false;
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   if (s & 1) {
     mayUseShortThunk = false;
     return false;
@@ -605,7 +611,8 @@ void ARMThunk::writeTo(uint8_t *buf) {
     return;
   }
 
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   uint64_t p = getThunkTargetSym()->getVA();
   int64_t offset = s - p - 8;
   write32(buf, 0xea000000); // b S
@@ -631,7 +638,8 @@ bool ARMThunk::isCompatibleWith(const InputSection &isec,
 bool ThumbThunk::getMayUseShortThunk() {
   if (!mayUseShortThunk || !config->armJ1J2BranchEncoding)
     return false;
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   if ((s & 1) == 0) {
     mayUseShortThunk = false;
     return false;
@@ -648,7 +656,8 @@ void ThumbThunk::writeTo(uint8_t *buf) {
     return;
   }
 
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   uint64_t p = getThunkTargetSym()->getVA();
   int64_t offset = s - p - 4;
   write16(buf + 0, 0xf000); // b.w S
@@ -670,7 +679,8 @@ void ARMV7ABSLongThunk::writeLong(uint8_t *buf) {
   write32(buf + 0, 0xe300c000); // movw ip,:lower16:S
   write32(buf + 4, 0xe340c000); // movt ip,:upper16:S
   write32(buf + 8, 0xe12fff1c); // bx   ip
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   target->relocateNoSym(buf, R_ARM_MOVW_ABS_NC, s);
   target->relocateNoSym(buf + 4, R_ARM_MOVT_ABS, s);
 }
@@ -687,7 +697,8 @@ void ThumbV7ABSLongThunk::writeLong(uint8_t *buf) {
   write16(buf + 4, 0xf2c0); // movt ip, :upper16:S
   write16(buf + 6, 0x0c00);
   write16(buf + 8, 0x4760); // bx   ip
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   target->relocateNoSym(buf, R_ARM_THM_MOVW_ABS_NC, s);
   target->relocateNoSym(buf + 4, R_ARM_THM_MOVT_ABS, s);
 }
@@ -703,7 +714,8 @@ void ARMV7PILongThunk::writeLong(uint8_t *buf) {
   write32(buf + 4, 0xe340c000);   //     movt ip,:upper16:S - (P + (L1-P) + 8)
   write32(buf + 8, 0xe08cc00f);   // L1: add  ip, ip, pc
   write32(buf + 12, 0xe12fff1c);  //     bx   ip
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   uint64_t p = getThunkTargetSym()->getVA();
   int64_t offset = s - p - 16;
   target->relocateNoSym(buf, R_ARM_MOVW_PREL_NC, offset);
@@ -723,7 +735,8 @@ void ThumbV7PILongThunk::writeLong(uint8_t *buf) {
   write16(buf + 6, 0x0c00);
   write16(buf + 8, 0x44fc);   // L1: add  ip, pc
   write16(buf + 10, 0x4760);  //     bx   ip
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   uint64_t p = getThunkTargetSym()->getVA() & ~0x1;
   int64_t offset = s - p - 12;
   target->relocateNoSym(buf, R_ARM_THM_MOVW_PREL_NC, offset);
@@ -746,7 +759,8 @@ void ThumbV6MABSLongThunk::writeLong(uint8_t *buf) {
   write16(buf + 4, 0x9001);   // str r0, [sp, #4] ; SP + 4 = S
   write16(buf + 6, 0xbd01);   // pop {r0, pc} ; restore r0 and branch to dest
   write32(buf + 8, 0x00000000);   // L1: .word S
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   target->relocateNoSym(buf + 8, R_ARM_ABS32, s);
 }
 
@@ -773,7 +787,8 @@ void ThumbV6MABSXOLongThunk::writeLong(uint8_t *buf) {
   write16(buf + 14, 0x3000); // adds r0, :lower0_7:S
   write16(buf + 16, 0x9001); // str r0, [sp, #4] ; SP + 4 = S
   write16(buf + 18, 0xbd01); // pop {r0, pc} ; restore r0 and branch to dest
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   target->relocateNoSym(buf + 2, R_ARM_THM_ALU_ABS_G3, s);
   target->relocateNoSym(buf + 6, R_ARM_THM_ALU_ABS_G2_NC, s);
   target->relocateNoSym(buf + 10, R_ARM_THM_ALU_ABS_G1_NC, s);
@@ -797,7 +812,8 @@ void ThumbV6MPILongThunk::writeLong(uint8_t *buf) {
   write16(buf + 8, 0x44e7);   // L1: add pc, ip       ; transfer control
   write16(buf + 10, 0x46c0);  //     nop              ; pad to 4-byte boundary
   write32(buf + 12, 0x00000000);  // L2: .word S - (P + (L1 - P) + 4)
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   uint64_t p = getThunkTargetSym()->getVA() & ~0x1;
   target->relocateNoSym(buf + 12, R_ARM_REL32, s - p - 12);
 }
@@ -813,7 +829,9 @@ void ThumbV6MPILongThunk::addSymbols(ThunkSection &isec) {
 void ARMV5LongLdrPcThunk::writeLong(uint8_t *buf) {
   write32(buf + 0, 0xe51ff004); // ldr pc, [pc,#-4] ; L1
   write32(buf + 4, 0x00000000); // L1: .word S
-  target->relocateNoSym(buf + 4, R_ARM_ABS32, getARMThunkDestVA(destination));
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  target->relocateNoSym(buf + 4, R_ARM_ABS32,
+                        getARMThunkDestVA(c, destination));
 }
 
 void ARMV5LongLdrPcThunk::addSymbols(ThunkSection &isec) {
@@ -828,7 +846,9 @@ void ARMV4ABSLongBXThunk::writeLong(uint8_t *buf) {
   write32(buf + 0, 0xe59fc000); // ldr r12, [pc] ; L1
   write32(buf + 4, 0xe12fff1c); // bx r12
   write32(buf + 8, 0x00000000); // L1: .word S
-  target->relocateNoSym(buf + 8, R_ARM_ABS32, getARMThunkDestVA(destination));
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  target->relocateNoSym(buf + 8, R_ARM_ABS32,
+                        getARMThunkDestVA(c, destination));
 }
 
 void ARMV4ABSLongBXThunk::addSymbols(ThunkSection &isec) {
@@ -844,7 +864,9 @@ void ThumbV4ABSLongBXThunk::writeLong(uint8_t *buf) {
   write16(buf + 2, 0xe7fd); // b #-6 ; Arm recommended sequence to follow bx pc
   write32(buf + 4, 0xe51ff004); // ldr pc, [pc, #-4] ; L1
   write32(buf + 8, 0x00000000); // L1: .word S
-  target->relocateNoSym(buf + 8, R_ARM_ABS32, getARMThunkDestVA(destination));
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  target->relocateNoSym(buf + 8, R_ARM_ABS32,
+                        getARMThunkDestVA(c, destination));
 }
 
 void ThumbV4ABSLongBXThunk::addSymbols(ThunkSection &isec) {
@@ -862,7 +884,9 @@ void ThumbV4ABSLongThunk::writeLong(uint8_t *buf) {
   write32(buf + 4, 0xe59fc000); // ldr r12, [pc] ; L1
   write32(buf + 8, 0xe12fff1c); // bx r12
   write32(buf + 12, 0x00000000); // L1: .word S
-  target->relocateNoSym(buf + 12, R_ARM_ABS32, getARMThunkDestVA(destination));
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  target->relocateNoSym(buf + 12, R_ARM_ABS32,
+                        getARMThunkDestVA(c, destination));
 }
 
 void ThumbV4ABSLongThunk::addSymbols(ThunkSection &isec) {
@@ -879,7 +903,8 @@ void ARMV4PILongBXThunk::writeLong(uint8_t *buf) {
   write32(buf + 4, 0xe08fc00c);	// L1: add ip, pc, ip
   write32(buf + 8, 0xe12fff1c);	//     bx ip
   write32(buf + 12, 0x00000000); // L2: .word S - (P + (L1 - P) + 8)
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   uint64_t p = getThunkTargetSym()->getVA() & ~0x1;
   target->relocateNoSym(buf + 12, R_ARM_REL32, s - p - 12);
 }
@@ -896,7 +921,8 @@ void ARMV4PILongThunk::writeLong(uint8_t *buf) {
   write32(buf + 0, 0xe59fc000); // P:  ldr ip, [pc] ; L2
   write32(buf + 4, 0xe08ff00c); // L1: add pc, pc, r12
   write32(buf + 8, 0x00000000); // L2: .word S - (P + (L1 - P) + 8)
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   uint64_t p = getThunkTargetSym()->getVA() & ~0x1;
   target->relocateNoSym(buf + 8, R_ARM_REL32, s - p - 12);
 }
@@ -915,7 +941,8 @@ void ThumbV4PILongBXThunk::writeLong(uint8_t *buf) {
   write32(buf + 4, 0xe59fc000); //     ldr r12, [pc] ; L2
   write32(buf + 8, 0xe08cf00f); // L1: add pc, r12, pc
   write32(buf + 12, 0x00000000); // L2: .word S - (P + (L1 - P) + 8)
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   uint64_t p = getThunkTargetSym()->getVA() & ~0x1;
   target->relocateNoSym(buf + 12, R_ARM_REL32, s - p - 16);
 }
@@ -936,7 +963,8 @@ void ThumbV4PILongThunk::writeLong(uint8_t *buf) {
   write32(buf + 8, 0xe08fc00c); // L1: add ip, pc, ip
   write32(buf + 12, 0xe12fff1c); //     bx ip
   write32(buf + 16, 0x00000000); // L2: .word S - (P + (L1 - P) + 8)
-  uint64_t s = getARMThunkDestVA(destination);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  uint64_t s = getARMThunkDestVA(c, destination);
   uint64_t p = getThunkTargetSym()->getVA() & ~0x1;
   target->relocateNoSym(buf + 16, R_ARM_REL32, s - p - 16);
 }
@@ -1033,7 +1061,8 @@ InputSection *MicroMipsR6Thunk::getTargetInputSection() const {
 }
 
 void elf::writePPC32PltCallStub(uint8_t *buf, uint64_t gotPltVA,
-                                const InputFile *file, int64_t addend) {
+                                const InputFile *file, const Compartment &c,
+                                int64_t addend) {
   if (!config->isPic) {
     write32(buf + 0, 0x3d600000 | (gotPltVA + 0x8000) >> 16); // lis r11,ha
     write32(buf + 4, 0x816b0000 | (uint16_t)gotPltVA);        // lwz r11,l(r11)
@@ -1052,7 +1081,7 @@ void elf::writePPC32PltCallStub(uint8_t *buf, uint64_t gotPltVA,
   } else {
     // The stub loads an address relative to _GLOBAL_OFFSET_TABLE_ (which is
     // currently the address of .got).
-    offset = gotPltVA - in.got->getVA();
+    offset = gotPltVA - c.got->getVA();
   }
   uint16_t ha = (offset + 0x8000) >> 16, l = (uint16_t)offset;
   if (ha == 0) {
@@ -1069,7 +1098,8 @@ void elf::writePPC32PltCallStub(uint8_t *buf, uint64_t gotPltVA,
 }
 
 void PPC32PltCallStub::writeTo(uint8_t *buf) {
-  writePPC32PltCallStub(buf, destination.getGotPltVA(), file, addend);
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  writePPC32PltCallStub(buf, destination.getGotPltVA(c), file, c, addend);
 }
 
 void PPC32PltCallStub::addSymbols(ThunkSection &isec) {
@@ -1129,7 +1159,8 @@ void elf::writePPC64LoadAndBranch(uint8_t *buf, int64_t offset) {
 }
 
 void PPC64PltCallStub::writeTo(uint8_t *buf) {
-  int64_t offset = destination.getGotPltVA() - getPPC64TocBase();
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  int64_t offset = destination.getGotPltVA(c) - getPPC64TocBase();
   // Save the TOC pointer to the save-slot reserved in the call frame.
   write32(buf + 0, 0xf8410018); // std     r2,24(r1)
   writePPC64LoadAndBranch(buf + 4, offset);
@@ -1191,7 +1222,8 @@ bool PPC64R2SaveStub::isCompatibleWith(const InputSection &isec,
 }
 
 void PPC64R12SetupStub::writeTo(uint8_t *buf) {
-  int64_t offset = (gotPlt ? destination.getGotPltVA() : destination.getVA()) -
+  Compartment &c = *getThunkTargetSym()->containingCompartment();
+  int64_t offset = (gotPlt ? destination.getGotPltVA(c) : destination.getVA()) -
                    getThunkTargetSym()->getVA();
   if (!isInt<34>(offset))
     reportRangeError(buf, offset, 34, destination, "R12 setup stub offset");
@@ -1418,12 +1450,13 @@ static Thunk *addThunkPPC32(const InputSection &isec, const Relocation &rel,
   assert((rel.type == R_PPC_LOCAL24PC || rel.type == R_PPC_REL24 ||
           rel.type == R_PPC_PLTREL24) &&
          "unexpected relocation type for thunk");
-  if (s.isInPlt())
+  if (s.isInPlt(isec.getCompartment()))
     return make<PPC32PltCallStub>(isec, rel, s);
   return make<PPC32LongThunk>(s, rel.addend);
 }
 
-static Thunk *addThunkPPC64(RelType type, Symbol &s, int64_t a) {
+static Thunk *addThunkPPC64(const InputSection &isec, RelType type, Symbol &s,
+                            int64_t a) {
   assert((type == R_PPC64_REL14 || type == R_PPC64_REL24 ||
           type == R_PPC64_REL24_NOTOC) &&
          "unexpected relocation type for thunk");
@@ -1433,7 +1466,7 @@ static Thunk *addThunkPPC64(RelType type, Symbol &s, int64_t a) {
   if (type == R_PPC64_REL24_NOTOC)
     getPPC64TargetInfo()->ppc64DynamicSectionOpt = 0x2;
 
-  if (s.isInPlt())
+  if (s.isInPlt(isec.getCompartment()))
     return type == R_PPC64_REL24_NOTOC
                ? (Thunk *)make<PPC64R12SetupStub>(s, /*gotPlt=*/true)
                : (Thunk *)make<PPC64PltCallStub>(s);
@@ -1469,7 +1502,7 @@ Thunk *elf::addThunk(const InputSection &isec, Relocation &rel) {
   case EM_PPC:
     return addThunkPPC32(isec, rel, s);
   case EM_PPC64:
-    return addThunkPPC64(rel.type, s, a);
+    return addThunkPPC64(isec, rel.type, s, a);
   default:
     llvm_unreachable("add Thunk only supported for ARM, AVR, Mips and PowerPC");
   }

--- a/lld/ELF/Thunks.h
+++ b/lld/ELF/Thunks.h
@@ -70,7 +70,8 @@ public:
 Thunk *addThunk(const InputSection &isec, Relocation &rel);
 
 void writePPC32PltCallStub(uint8_t *buf, uint64_t gotPltVA,
-                           const InputFile *file, int64_t addend);
+                           const InputFile *file, const Compartment &c,
+                           int64_t addend);
 void writePPC64LoadAndBranch(uint8_t *buf, int64_t offset);
 
 } // namespace lld::elf

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -61,7 +61,7 @@ private:
   void finalizeAddressDependentContent();
   void optimizeBasicBlockJumps();
   void sortInputSections();
-  void sortCheriPccPaddingSection();
+  void sortCheriPccPaddingSection(Compartment &c);
   void sortOrphanSections();
   void finalizeSections();
   void checkExecuteOnly();
@@ -300,6 +300,10 @@ template <class ELFT> void elf::createSyntheticSections() {
 
   auto add = [](SyntheticSection &sec) { ctx.inputSections.push_back(&sec); };
 
+  if (compartments.size() > 1)
+    in.compartStrTab =
+        std::make_unique<StringTableSection>(".c18nstrtab", true);
+
   in.shStrTab = std::make_unique<StringTableSection>(".shstrtab", false);
 
   Out::programHeaders = make<OutputSection>("", 0, SHF_ALLOC);
@@ -449,6 +453,9 @@ template <class ELFT> void elf::createSyntheticSections() {
   }
 
   if (partitions.size() != 1) {
+    if (compartments.size() > 1)
+      error("Compartments are not supported with partitions");
+
     // Create the partition end marker. This needs to be in partition number 255
     // so that it is sorted after all other partitions. It also has other
     // special handling (see createPhdrs() and combineEhSections()).
@@ -470,26 +477,38 @@ template <class ELFT> void elf::createSyntheticSections() {
     in.mipsGot = std::make_unique<MipsGotSection>();
     add(*in.mipsGot);
   } else {
-    in.got = std::make_unique<GotSection>();
-    add(*in.got);
+    for (Compartment &compart : compartments) {
+      compart.got = std::make_unique<GotSection>();
+      compart.got->compartment = compart.getNumber();
+      add(*compart.got);
+    }
   }
 
   if (config->emachine == EM_PPC) {
+    if (compartments.size() > 1)
+      error("Compartments are not supported with for EM_PCC");
     in.ppc32Got2 = std::make_unique<PPC32Got2Section>();
     add(*in.ppc32Got2);
   }
 
   if (config->emachine == EM_PPC64) {
+    if (compartments.size() > 1)
+      error("Compartments are not supported with for EM_PCC64");
     in.ppc64LongBranchTarget = std::make_unique<PPC64LongBranchTargetSection>();
     add(*in.ppc64LongBranchTarget);
   }
 
-  in.gotPlt = std::make_unique<GotPltSection>();
-  add(*in.gotPlt);
-  in.igotPlt = std::make_unique<IgotPltSection>();
-  add(*in.igotPlt);
-  in.tgot = std::make_unique<TgotSection>();
-  add(*in.tgot);
+  for (Compartment &compart : compartments) {
+    compart.gotPlt = std::make_unique<GotPltSection>();
+    compart.gotPlt->compartment = compart.getNumber();
+    add(*compart.gotPlt);
+    compart.igotPlt = std::make_unique<IgotPltSection>();
+    compart.igotPlt->compartment = compart.getNumber();
+    add(*compart.igotPlt);
+    compart.tgot = std::make_unique<TgotSection>();
+    compart.tgot->compartment = compart.getNumber();
+    add(*compart.tgot);
+  }
 
   if (config->emachine == EM_ARM) {
     in.armCmseSGSection = std::make_unique<ArmCmseSGSection>();
@@ -498,11 +517,13 @@ template <class ELFT> void elf::createSyntheticSections() {
 
   // _GLOBAL_OFFSET_TABLE_ is defined relative to either .got.plt or .got. Treat
   // it as a relocation and ensure the referenced section is created.
+  //
+  // TODO: _GLOBAL_OFFSET_TABLE_ should be compartment-relative?
   if (ElfSym::globalOffsetTable && config->emachine != EM_MIPS) {
     if (target->gotBaseSymInGotPlt)
-      in.gotPlt->hasGotPltOffRel = true;
+      defaultCompart->gotPlt->hasGotPltOffRel = true;
     else
-      in.got->hasGotOffRel = true;
+      defaultCompart->got->hasGotOffRel = true;
   }
 
   if (config->gdbIndex)
@@ -510,10 +531,13 @@ template <class ELFT> void elf::createSyntheticSections() {
 
   // We always need to add rel[a].plt to output if it has entries.
   // Even for static linking it can contain R_[*]_IRELATIVE relocations.
-  in.relaPlt = std::make_unique<RelocationSection<ELFT>>(
-      config->isRela ? ".rela.plt" : ".rel.plt", /*sort=*/false,
-      /*threadCount=*/1);
-  add(*in.relaPlt);
+  for (Compartment &compart : compartments) {
+    compart.relaPlt = std::make_unique<RelocationSection<ELFT>>(
+        config->isRela ? ".rela.plt" : ".rel.plt", /*sort=*/false,
+        /*threadCount=*/1);
+    compart.relaPlt->compartment = compart.getNumber();
+    add(*compart.relaPlt);
+  }
 
   // The relaIplt immediately follows .rel[a].dyn to ensure that the IRelative
   // relocations are processed last by the dynamic loader. We cannot place the
@@ -522,7 +546,8 @@ template <class ELFT> void elf::createSyntheticSections() {
   // dynamic loader reads .rel.plt after .rel.dyn, we can get the desired
   // behaviour by placing the iplt section in .rel.plt.
   in.relaIplt = std::make_unique<RelocationSection<ELFT>>(
-      config->androidPackDynRelocs ? in.relaPlt->name : relaDynName,
+      config->androidPackDynRelocs ? defaultCompart->relaPlt->name
+                                   : relaDynName,
       /*sort=*/false, /*threadCount=*/1);
   add(*in.relaIplt);
 
@@ -537,21 +562,30 @@ template <class ELFT> void elf::createSyntheticSections() {
 
   if ((config->emachine == EM_386 || config->emachine == EM_X86_64) &&
       (config->andFeatures & GNU_PROPERTY_X86_FEATURE_1_IBT)) {
+    if (compartments.size() > 1)
+      error("Compartments are not supported with IBT");
     in.ibtPlt = std::make_unique<IBTPltSection>();
     add(*in.ibtPlt);
   }
 
-  if (config->emachine == EM_PPC)
-    in.plt = std::make_unique<PPC32GlinkSection>();
-  else
-    in.plt = std::make_unique<PltSection>();
-  add(*in.plt);
-  in.iplt = std::make_unique<IpltSection>();
-  add(*in.iplt);
+  for (Compartment &compart : compartments) {
+    if (config->emachine == EM_PPC)
+      compart.plt = std::make_unique<PPC32GlinkSection>();
+    else
+      compart.plt = std::make_unique<PltSection>();
+    compart.plt->compartment = compart.getNumber();
+    add(*compart.plt);
+    compart.iplt = std::make_unique<IpltSection>();
+    compart.iplt->compartment = compart.getNumber();
+    add(*compart.iplt);
+  }
 
   if (config->isCheriAbi && needsCheriPccSegment()) {
-    in.pccPadding = std::make_unique<CheriPccPaddingSection>();
-    add(*in.pccPadding);
+    for (Compartment &compart : compartments) {
+      compart.pccPadding = std::make_unique<CheriPccPaddingSection>();
+      compart.pccPadding->compartment = compart.getNumber();
+      add(*compart.pccPadding);
+    }
   }
 
   if (config->andFeatures)
@@ -572,6 +606,8 @@ template <class ELFT> void elf::createSyntheticSections() {
   add(*in.shStrTab);
   if (in.strTab)
     add(*in.strTab);
+  if (in.compartStrTab)
+    add(*in.compartStrTab);
 }
 
 // The main function of the writer.
@@ -805,6 +841,18 @@ template <class ELFT> void Writer<ELFT>::addSectionSymbols() {
   }
 }
 
+// Sections with some special names are put into RELRO. This is a
+// bit unfortunate because section names shouldn't be significant in
+// ELF in spirit. But in reality many linker features depend on
+// magic section names.
+bool elf::isRelroSection(StringRef s) {
+  return s == ".data.rel.ro" || s == ".bss.rel.ro" || s == ".ctors" ||
+         s == ".dtors" || s == ".jcr" || s == ".eh_frame" ||
+         s == ".fini_array" || s == ".init_array" ||
+         s == ".openbsd.randomdata" || s == ".preinit_array" ||
+         s == "__cap_relocs" || s == ".gcc_except_table";
+}
+
 // Today's loaders have a feature to make segments read-only after
 // processing dynamic relocations to enhance security. PT_GNU_RELRO
 // is defined for that.
@@ -817,6 +865,7 @@ bool elf::isRelroSection(const OutputSection *sec, bool ignoreZRelro) {
   if (sec->relro)
     return true;
 
+  const Compartment &c = sec->getCompartment();
   uint64_t flags = sec->flags;
 
   // Non-allocatable or non-writable sections don't need RELRO because
@@ -848,7 +897,7 @@ bool elf::isRelroSection(const OutputSection *sec, bool ignoreZRelro) {
   // .got contains pointers to external symbols. They are resolved by
   // the dynamic linker when a module is loaded into memory, and after
   // that they are not expected to change. So, it can be in RELRO.
-  if (in.got && sec == in.got->getParent())
+  if (c.got && sec == c.got->getParent())
     return true;
 
   // .toc is a GOT-ish section for PowerPC64. Their contents are accessed
@@ -863,7 +912,7 @@ bool elf::isRelroSection(const OutputSection *sec, bool ignoreZRelro) {
   // by default resolved lazily, so we usually cannot put it into RELRO.
   // However, if "-z now" is given, the lazy symbol resolution is
   // disabled, which enables us to put it into RELRO.
-  if (sec == in.gotPlt->getParent())
+  if (sec == c.gotPlt->getParent())
     return config->zNow;
 
   // Similarly the CHERI capability table is also relro since the capabilities
@@ -880,16 +929,7 @@ bool elf::isRelroSection(const OutputSection *sec, bool ignoreZRelro) {
   if (sec->name == ".dynamic")
     return true;
 
-  // Sections with some special names are put into RELRO. This is a
-  // bit unfortunate because section names shouldn't be significant in
-  // ELF in spirit. But in reality many linker features depend on
-  // magic section names.
-  StringRef s = sec->name;
-  return s == ".data.rel.ro" || s == ".bss.rel.ro" || s == ".ctors" ||
-         s == ".dtors" || s == ".jcr" || s == ".eh_frame" ||
-         s == ".fini_array" || s == ".init_array" ||
-         s == ".openbsd.randomdata" || s == ".preinit_array" ||
-         s == "__cap_relocs" || s == ".gcc_except_table";
+  return isRelroSection(sec->name);
 }
 
 // We compute a rank for each section. The rank indicates where the
@@ -903,19 +943,30 @@ enum RankFlags {
   RF_NOT_ADDR_SET = 1 << 27,
   RF_NOT_ALLOC = 1 << 26,
   RF_PARTITION = 1 << 18, // Partition number (8 bits)
+  RF_COMPARTMENT = RF_PARTITION,
   RF_NOT_SPECIAL = 1 << 17,
   RF_WRITE = 1 << 16,
   RF_EXEC_WRITE = 1 << 15,
   RF_EXEC = 1 << 14,
   RF_RODATA = 1 << 13,
   RF_LARGE = 1 << 12,
-  RF_NOT_RELRO = 1 << 9,
+  RF_NOT_RELRO = 1 << 10,
+  RF_NOT_TGOT = 1 << 9,
   RF_NOT_TLS = 1 << 8,
   RF_BSS = 1 << 7,
 };
 
 static unsigned getSectionRank(const OutputSection &osec) {
   unsigned rank = osec.partition * RF_PARTITION;
+  const Compartment &c = osec.getCompartment();
+
+  // The default compartment uses an index of 0, which we leave as using the
+  // partition number for the rank. Since the partition number of mainPart is
+  // 1, increment the index so that additional compartments start at 2 for
+  // their ranks. However, TGOT sections get grouped together into a single
+  // segment.
+  if (osec.compartment != 0 && &osec != c.tgot->getParent())
+    rank = (osec.compartment + 1) * RF_COMPARTMENT;
 
   // We want to put section specified by -T option first, so we
   // can start assigning VA starting from them later.
@@ -979,6 +1030,8 @@ static unsigned getSectionRank(const OutputSection &osec) {
     // TLS sections directly before the other RELRO sections.
     if (!(osec.flags & SHF_TLS))
       rank |= RF_NOT_TLS;
+    if (&osec != c.tgot->getParent())
+      rank |= RF_NOT_TGOT;
     if (!isRelroSection(&osec))
       rank |= RF_NOT_RELRO;
     // Place .ldata and .lbss after .bss. Making .bss closer to .text alleviates
@@ -1083,10 +1136,10 @@ template <class ELFT> void Writer<ELFT>::setReservedSymbolSections() {
   if (ElfSym::globalOffsetTable) {
     // The _GLOBAL_OFFSET_TABLE_ symbol is defined by target convention usually
     // to the start of the .got or .got.plt section.
-    InputSection *sec = in.gotPlt.get();
+    InputSection *sec = defaultCompart->gotPlt.get();
     if (!target->gotBaseSymInGotPlt)
       sec = in.mipsGot ? cast<InputSection>(in.mipsGot.get())
-                       : cast<InputSection>(in.got.get());
+                       : cast<InputSection>(defaultCompart->got.get());
     ElfSym::globalOffsetTable->section = sec;
   }
 
@@ -1487,8 +1540,9 @@ template <class ELFT> void Writer<ELFT>::sortInputSections() {
 
 // The CHERI PCC padding output section must be placed immediately after the
 // last section covered by the PCC bounds.
-template <class ELFT> void Writer<ELFT>::sortCheriPccPaddingSection() {
-  CheriPccPaddingSection *psec = in.pccPadding.get();
+template <class ELFT>
+void Writer<ELFT>::sortCheriPccPaddingSection(Compartment &c) {
+  CheriPccPaddingSection *psec = c.pccPadding.get();
   if (!psec->isNeeded())
     return;
 
@@ -1503,10 +1557,11 @@ template <class ELFT> void Writer<ELFT>::sortCheriPccPaddingSection() {
   auto paddingSec = *fromPos;
   script->sectionCommands.erase(fromPos);
 
-  // Second, find the last CHERI PCC output section.
+  // Second, find the last CHERI PCC output section for this compartment.
   auto isPccSection = [&](SectionCommand *cmd) {
     auto *to = dyn_cast<OutputDesc>(cmd);
-    return to != nullptr && to->osec.cheriPcc;
+    return to != nullptr && to->osec.compartment == c.getNumber() &&
+           to->osec.cheriPcc;
   };
 
   auto insertPos = llvm::find_if(script->sectionCommands, isPccSection);
@@ -1561,8 +1616,9 @@ template <class ELFT> void Writer<ELFT>::sortSections() {
   if (script->hasSectionsCommand)
     sortOrphanSections();
 
-  if (in.pccPadding)
-    sortCheriPccPaddingSection();
+  for (Compartment &c : compartments)
+    if (c.pccPadding)
+      sortCheriPccPaddingSection(c);
 
   script->adjustSectionsAfterSorting();
 }
@@ -1892,6 +1948,7 @@ template <class ELFT> void Writer<ELFT>::optimizeBasicBlockJumps() {
 // Which output sections are always covered by CHERI PCC bounds.  This includes
 // executable sections, GOTs, and PCC padding.
 static bool isCheriBoundsSection(const OutputSection *sec) {
+  const Compartment &c = sec->getCompartment();
   uint64_t flags = sec->flags;
 
   // Non-allocatable sections are not mapped into memory.
@@ -1903,15 +1960,15 @@ static bool isCheriBoundsSection(const OutputSection *sec) {
     return true;
 
   // .got is accessed relative to PCC.
-  if (in.got && sec == in.got->getParent())
+  if (c.got && sec == c.got->getParent())
     return true;
   if (in.mipsGot && sec == in.mipsGot->getParent())
     return true;
 
   // .got.plt is accessed relative to PCC.
-  if (sec == in.gotPlt->getParent())
+  if (sec == c.gotPlt->getParent())
     return true;
-  if (sec == in.igotPlt->getParent())
+  if (sec == c.igotPlt->getParent())
     return true;
 
   // CHERI-MIPS capability table is accessed relative to PCC.
@@ -1919,13 +1976,13 @@ static bool isCheriBoundsSection(const OutputSection *sec) {
     return true;
 
   // The PCC padding section is included in PCC bounds.
-  if (sec == in.pccPadding->getParent())
+  if (sec == c.pccPadding->getParent())
     return true;
 
   // XXX: CheriBSD's runtime loader assumes all read-only capabilities can be
   // derived from PCC, so include all read-only sections as a workaround for
   // now.  Once CheriBSD 25.03 is no longer supported, this can be removed.
-  if (sec->type == SHT_PROGBITS && sec != in.tgot->getParent() &&
+  if (sec->type == SHT_PROGBITS && sec != c.tgot->getParent() &&
       ((flags & SHF_WRITE) == 0 || isRelroSection(sec, /*ignoreZRelro=*/true)))
     return true;
 
@@ -1947,51 +2004,39 @@ static void markCheriPccSections() {
     // Ignore empty input sections
     if (s->getSize() == 0)
       continue;
-    if ((s->flags & (SHF_ALLOC | SHF_EXECINSTR)) ==
-        (SHF_ALLOC | SHF_EXECINSTR)) {
-      in.pccPadding->markNeeded();
-      break;
-    }
+    if ((s->flags & (SHF_ALLOC | SHF_EXECINSTR)) == (SHF_ALLOC | SHF_EXECINSTR))
+      s->getCompartment().pccPadding->markNeeded();
   }
 
   // Even if all executable input sections are empty, there may be a symbol
   // defined in one, for which we need to have CHERI PCC bounds.
-  if (!in.pccPadding->isNeeded()) {
-    for (Symbol *sym : symtab.getSymbols()) {
+  for (Symbol *sym : symtab.getSymbols()) {
+    Defined *d = dyn_cast<Defined>(sym);
+    if (!d || !d->section)
+      continue;
+    if ((d->section->flags & (SHF_ALLOC | SHF_EXECINSTR)) ==
+        (SHF_ALLOC | SHF_EXECINSTR))
+      d->section->getCompartment().pccPadding->markNeeded();
+  }
+
+  for (ELFFileBase *file : ctx.objectFiles) {
+    for (Symbol *sym : file->getLocalSymbols()) {
       Defined *d = dyn_cast<Defined>(sym);
       if (!d || !d->section)
         continue;
       if ((d->section->flags & (SHF_ALLOC | SHF_EXECINSTR)) ==
-          (SHF_ALLOC | SHF_EXECINSTR)) {
-        in.pccPadding->markNeeded();
-        break;
-      }
+          (SHF_ALLOC | SHF_EXECINSTR))
+        d->section->getCompartment().pccPadding->markNeeded();
     }
   }
-
-  if (!in.pccPadding->isNeeded()) {
-    for (ELFFileBase *file : ctx.objectFiles) {
-      for (Symbol *sym : file->getLocalSymbols()) {
-        Defined *d = dyn_cast<Defined>(sym);
-        if (!d || !d->section)
-          continue;
-        if ((d->section->flags & (SHF_ALLOC | SHF_EXECINSTR)) ==
-            (SHF_ALLOC | SHF_EXECINSTR)) {
-          in.pccPadding->markNeeded();
-          break;
-        }
-      }
-    }
-  }
-
-  if (!in.pccPadding->isNeeded())
-    return;
 
   // Mark all output sections accessed via PCC if there is at least one
   // executable input section.
   for (SectionCommand *cmd : script->sectionCommands) {
     if (auto *osd = dyn_cast<OutputDesc>(cmd)) {
       OutputSection &osec = osd->osec;
+      if (!osec.getCompartment().pccPadding->isNeeded())
+        continue;
       if (isCheriBoundsSection(&osec))
         osec.cheriPcc.store(true, std::memory_order_relaxed);
     }
@@ -2192,10 +2237,12 @@ template <class ELFT> void Writer<ELFT>::finalizeSections() {
     for (Partition &part : partitions)
       finalizeSynthetic(part.capRelocs.get());
     finalizeSynthetic(in.tgotCapRelocs.get());
-    if (in.plt && in.plt->isNeeded())
-      in.plt->addSymbols();
-    if (in.iplt && in.iplt->isNeeded())
-      in.iplt->addSymbols();
+    for (Compartment &c : compartments) {
+      if (c.plt && c.plt->isNeeded())
+        c.plt->addSymbols();
+      if (c.iplt && c.iplt->isNeeded())
+        c.iplt->addSymbols();
+    }
 
     if (config->unresolvedSymbolsInShlib != UnresolvedPolicy::Ignore) {
       auto diagnose =
@@ -2261,7 +2308,7 @@ template <class ELFT> void Writer<ELFT>::finalizeSections() {
   if (in.mipsGot)
     in.mipsGot->build();
 
-  if (in.pccPadding)
+  if (config->isCheriAbi && needsCheriPccSegment())
     markCheriPccSections();
   removeUnusedSyntheticSections();
   script->diagnoseOrphanHandling();
@@ -2345,22 +2392,26 @@ template <class ELFT> void Writer<ELFT>::finalizeSections() {
 
     finalizeSynthetic(in.bss.get());
     finalizeSynthetic(in.bssRelRo.get());
+    finalizeSynthetic(in.compartStrTab.get());
     finalizeSynthetic(in.symTabShndx.get());
     finalizeSynthetic(in.shStrTab.get());
     finalizeSynthetic(in.strTab.get());
-    finalizeSynthetic(in.got.get());
     finalizeSynthetic(in.mipsGot.get());
-    finalizeSynthetic(in.igotPlt.get());
-    finalizeSynthetic(in.gotPlt.get());
-    finalizeSynthetic(in.tgot.get());
-    finalizeSynthetic(in.pccPadding.get());
     finalizeSynthetic(in.relaIplt.get());
-    finalizeSynthetic(in.relaPlt.get());
     finalizeSynthetic(in.relaTgot.get());
-    finalizeSynthetic(in.plt.get());
-    finalizeSynthetic(in.iplt.get());
     finalizeSynthetic(in.ppc32Got2.get());
     finalizeSynthetic(in.partIndex.get());
+
+    for (Compartment &c : compartments) {
+      finalizeSynthetic(c.got.get());
+      finalizeSynthetic(c.gotPlt.get());
+      finalizeSynthetic(c.igotPlt.get());
+      finalizeSynthetic(c.tgot.get());
+      finalizeSynthetic(c.pccPadding.get());
+      finalizeSynthetic(c.relaPlt.get());
+      finalizeSynthetic(c.plt.get());
+      finalizeSynthetic(c.iplt.get());
+    }
 
     // Dynamic section must be the last one in this list and dynamic
     // symbol table section (dynSymTab) must be the first one.
@@ -2627,42 +2678,72 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
     }
   }
 
+  // PT_C18N_NAME spans all the sections belonging to each compartment.
+  Compartment *lastCompartment = nullptr;
+  for (OutputSection *sec : outputSections) {
+    if (sec->partition != partNo || !needsPtLoad(sec))
+      continue;
+    Compartment &c = sec->getCompartment();
+    if (!c.isDefault()) {
+      if (&c != lastCompartment) {
+        if (c.phdrs.empty())
+          c.nameIndex = in.compartStrTab->addString(c.name);
+        c.phdrs.push_back(make<PhdrEntry>(PT_C18N_NAME, 0));
+      }
+      c.phdrs.back()->add(sec);
+    }
+    lastCompartment = &c;
+  }
+
   // PT_GNU_RELRO includes all sections that should be marked as
   // read-only by dynamic linker after processing relocations.
   // Current dynamic loaders only support one PT_GNU_RELRO PHDR, give
   // an error message if more than one PT_GNU_RELRO PHDR is required.
-  PhdrEntry *relRo = make<PhdrEntry>(PT_GNU_RELRO, PF_R);
+  for (Compartment &compart : compartments)
+    compart.relRo = make<PhdrEntry>(PT_GNU_RELRO, PF_R);
+
+  PhdrEntry *relRo = nullptr;
   bool inRelroPhdr = false;
-  OutputSection *relroEnd = nullptr;
+  lastCompartment = nullptr;
   for (OutputSection *sec : outputSections) {
     if (sec->partition != partNo || !needsPtLoad(sec))
       continue;
+    Compartment &c = sec->getCompartment();
+    if (&c != lastCompartment) {
+      if (inRelroPhdr) {
+        inRelroPhdr = false;
+        sec->relroEnd = true;
+      }
+      lastCompartment = &c;
+      relRo = c.relRo;
+    }
     // Treat a CHERI PCC padding section as relro if it is preceded by a relro
     // section.
     if (isRelroSection(sec) ||
-        (in.pccPadding && inRelroPhdr && sec == in.pccPadding->getParent())) {
-      inRelroPhdr = true;
-      if (!relroEnd)
+        (c.pccPadding && inRelroPhdr && sec == c.pccPadding->getParent())) {
+      if (inRelroPhdr || !relRo->firstSec) {
+        inRelroPhdr = true;
         relRo->add(sec);
-      else
+      } else
         error("section: " + sec->name + " is not contiguous with other relro" +
               " sections");
     } else if (inRelroPhdr) {
       inRelroPhdr = false;
-      relroEnd = sec;
+      sec->relroEnd = true;
     }
   }
 
-  // Determine the sections PCC should cover.
-  if (in.pccPadding) {
-    in.cheriBounds = make<PhdrEntry>(PT_CHERI_PCC, PF_R | PF_X);
+  // Determine the sections PCC should cover for each compartment.
+  if (config->isCheriAbi && needsCheriPccSegment()) {
+    for (Compartment &compart : compartments)
+      compart.cheriBounds = make<PhdrEntry>(PT_CHERI_PCC, PF_R | PF_X);
 
     for (OutputSection *sec : outputSections) {
       if (sec->partition != partNo || !needsPtLoad(sec))
         continue;
       if (!sec->cheriPcc.load(std::memory_order_relaxed))
         continue;
-      in.cheriBounds->add(sec);
+      sec->getCompartment().cheriBounds->add(sec);
     }
   }
 
@@ -2701,7 +2782,7 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
     uint64_t newFlags = computeFlags(sec->getPhdrFlags());
     bool sameLMARegion =
         load && !sec->lmaExpr && sec->lmaRegion == load->firstSec->lmaRegion;
-    if (!(load && newFlags == flags && sec != relroEnd &&
+    if (!(load && newFlags == flags && !sec->relroEnd &&
           sec->memRegion == load->firstSec->memRegion &&
           (sameLMARegion || load->lastSec == Out::programHeaders) &&
           (script->hasSectionsCommand || sec->type == SHT_NOBITS ||
@@ -2721,22 +2802,39 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
   if (tlsHdr->firstSec)
     ret.push_back(tlsHdr);
 
-  // Add an entry for .tgot.
-  if (in.tgot->isNeeded()) {
-    OutputSection *sec = in.tgot->getParent();
-    addHdr(PT_CHERI_TGOT, sec->getPhdrFlags())->add(sec);
+  // Add entries for .tgot.
+  PhdrEntry *tgotHdr = make<PhdrEntry>(PT_CHERI_TGOT, PF_R);
+  for (Compartment &compart : compartments) {
+    if (compart.tgot->isNeeded()) {
+      OutputSection *sec = compart.tgot->getParent();
+      tgotHdr->add(sec);
+    }
   }
+  if (tgotHdr->firstSec)
+    ret.push_back(tgotHdr);
 
   // Add an entry for .dynamic.
   if (OutputSection *sec = part.dynamic->getParent())
     addHdr(PT_DYNAMIC, sec->getPhdrFlags())->add(sec);
 
-  if (relRo->firstSec)
-    ret.push_back(relRo);
+  for (Compartment &compart : compartments) {
+    if (compart.isDefault())
+      continue;
+    if (compart.phdrs.empty())
+      error("no output sections for compartment " + compart.name);
+    for (PhdrEntry *phdr : compart.phdrs)
+      ret.push_back(phdr);
+  }
 
-  if (in.cheriBounds) {
-    if (in.cheriBounds->firstSec)
-      ret.push_back(in.cheriBounds);
+  for (Compartment &compart : compartments)
+    if (compart.relRo->firstSec)
+      ret.push_back(compart.relRo);
+
+  for (Compartment &compart : compartments) {
+    if (compart.cheriBounds) {
+      if (compart.cheriBounds->firstSec)
+        ret.push_back(compart.cheriBounds);
+    }
   }
 
   // PT_GNU_EH_FRAME is a special section pointing on .eh_frame_hdr.
@@ -3028,6 +3126,11 @@ template <class ELFT> void Writer<ELFT>::setPhdrs(Partition &part) {
       p->p_memsz =
           alignToPowerOf2(p->p_offset + p->p_memsz, config->commonPageSize) -
           p->p_offset;
+    }
+
+    if (p->p_type == PT_C18N_NAME) {
+      // Store the name index in the paddr field.
+      p->p_paddr = first->getCompartment().nameIndex;
     }
   }
 }

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -841,18 +841,6 @@ template <class ELFT> void Writer<ELFT>::addSectionSymbols() {
   }
 }
 
-// Sections with some special names are put into RELRO. This is a
-// bit unfortunate because section names shouldn't be significant in
-// ELF in spirit. But in reality many linker features depend on
-// magic section names.
-bool elf::isRelroSection(StringRef s) {
-  return s == ".data.rel.ro" || s == ".bss.rel.ro" || s == ".ctors" ||
-         s == ".dtors" || s == ".jcr" || s == ".eh_frame" ||
-         s == ".fini_array" || s == ".init_array" ||
-         s == ".openbsd.randomdata" || s == ".preinit_array" ||
-         s == "__cap_relocs" || s == ".gcc_except_table";
-}
-
 // Today's loaders have a feature to make segments read-only after
 // processing dynamic relocations to enhance security. PT_GNU_RELRO
 // is defined for that.
@@ -929,7 +917,18 @@ bool elf::isRelroSection(const OutputSection *sec, bool ignoreZRelro) {
   if (sec->name == ".dynamic")
     return true;
 
-  return isRelroSection(sec->name);
+  // Sections with some special names are put into RELRO. This is a
+  // bit unfortunate because section names shouldn't be significant in
+  // ELF in spirit. But in reality many linker features depend on
+  // magic section names.
+  StringRef s = sec->name;
+  if (sec->compartment != 0)
+    s.consume_back(sec->getCompartment().suffix);
+  return s == ".data.rel.ro" || s == ".bss.rel.ro" || s == ".ctors" ||
+         s == ".dtors" || s == ".jcr" || s == ".eh_frame" ||
+         s == ".fini_array" || s == ".init_array" ||
+         s == ".openbsd.randomdata" || s == ".preinit_array" ||
+         s == "__cap_relocs" || s == ".gcc_except_table";
 }
 
 // We compute a rank for each section. The rank indicates where the

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -694,10 +694,10 @@ template <class ELFT> void Writer<ELFT>::run() {
 }
 
 template <class ELFT, class RelTy>
-static void markUsedLocalSymbolsImpl(ObjFile<ELFT> *file,
+static void markUsedLocalSymbolsImpl(const Compartment &c, ObjFile<ELFT> *file,
                                      llvm::ArrayRef<RelTy> rels) {
   for (const RelTy &rel : rels) {
-    Symbol &sym = file->getRelocTargetSym(rel);
+    Symbol &sym = file->getRelocTargetSym(c, rel);
     if (sym.isLocal())
       sym.used = true;
   }
@@ -716,10 +716,13 @@ template <class ELFT> static void markUsedLocalSymbols() {
       InputSection *isec = dyn_cast_or_null<InputSection>(s);
       if (!isec)
         continue;
-      if (isec->type == SHT_REL)
-        markUsedLocalSymbolsImpl(f, isec->getDataAs<typename ELFT::Rel>());
-      else if (isec->type == SHT_RELA)
-        markUsedLocalSymbolsImpl(f, isec->getDataAs<typename ELFT::Rela>());
+      if (isec->type == SHT_REL) {
+        const Compartment &c = f->getRelocTargetCompartment(isec);
+        markUsedLocalSymbolsImpl(c, f, isec->getDataAs<typename ELFT::Rel>());
+      } else if (isec->type == SHT_RELA) {
+        const Compartment &c = f->getRelocTargetCompartment(isec);
+        markUsedLocalSymbolsImpl(c, f, isec->getDataAs<typename ELFT::Rela>());
+      }
     }
   }
 }

--- a/lld/ELF/Writer.h
+++ b/lld/ELF/Writer.h
@@ -57,6 +57,7 @@ uint8_t getMipsIsaExt(uint64_t oldExt, llvm::StringRef oldFile, uint64_t newExt,
                       llvm::StringRef newFile);
 void checkMipsShlibCompatible(InputFile *f, uint64_t shlibCheriFlags,
                               uint64_t targetCheriFlags);
+bool isRelroSection(StringRef name);
 bool isRelroSection(const OutputSection *sec, bool ignoreZRelro = false);
 
 bool isMipsN32Abi(const InputFile *f);

--- a/lld/test/ELF/cheri/riscv/c18n/conflicting_symbols.s
+++ b/lld/test/ELF/cheri/riscv/c18n/conflicting_symbols.s
@@ -1,0 +1,31 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
+# RUN: not ld.lld --shared --verbose-c18n --compartment-policy=%t/compartments.json %t/one.o -o %t/conflicting_symbols.so.0 2>&1 | FileCheck %s
+
+# CHECK: one.o:.text assigned to compartment one by symbol foo and compartment two by symbol bar
+
+#--- one.s
+
+	.text
+	.global	foo
+	.type	foo, @function
+foo:
+	ret
+	.size	foo, . - foo
+
+	.global	bar
+	.type	bar, @function
+bar:
+	ret
+	.size	bar, . - bar
+
+#--- compartments.json
+
+{
+    "compartments": {
+	"one": { "symbols": ["foo"] },
+	"two": { "symbols": ["bar"] }
+    }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/empty_compartment.s
+++ b/lld/test/ELF/cheri/riscv/c18n/empty_compartment.s
@@ -1,0 +1,25 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
+# RUN: not ld.lld --shared --compartment-policy=%t/compartments.json %t/one.o -o %t/empty.so.0 2>&1 | FileCheck %s
+
+# CHECK: ld.lld: error: no output sections for compartment two
+
+#--- one.s
+
+	.text
+	.global	foo
+	.type	foo, @function
+foo:
+	ret
+	.size	foo, . - foo
+
+#--- compartments.json
+
+{
+    "compartments": {
+	"one": { "symbols": ["foo"] },
+	"two": { "symbols": ["bar"] }
+    }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/implicit_assignment.s
+++ b/lld/test/ELF/cheri/riscv/c18n/implicit_assignment.s
@@ -1,0 +1,119 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/two.s -o %t/two.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/two_hidden.s -o %t/two_hidden.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/three.s -o %t/three.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/three_hidden.s -o %t/three_hidden.o
+
+# Only imply 'buf'
+# RUN: ld.lld --shared --verbose-c18n --compartment-policy=%t/one.json %t/one.o -o %t/implicit_buf.so.0 2>&1 | FileCheck --check-prefixes=ONE,BUF %s
+
+# 'baz' can't be implied because it is exported
+# RUN: ld.lld --shared --verbose-c18n --compartment-policy=%t/one.json %t/one.o %t/two.o -o %t/implicit_baz_exported.so.0 2>&1 | FileCheck --check-prefixes=ONE,BUF,NOBAZ %s
+
+# Hidden 'baz' can be implied
+# RUN: ld.lld --shared --verbose-c18n --compartment-policy=%t/one.json %t/one.o %t/two_hidden.o -o %t/implicit_baz_hidden.so.0 2>&1 | FileCheck --check-prefixes=ONE,BUF,BAZ %s
+
+# Neither 'bar' nor 'baz' can be implied because they are exported
+# RUN: ld.lld --shared --verbose-c18n --compartment-policy=%t/one.json %t/one.o %t/two.o %t/three.o -o %t/implicit_bar_baz_exported.so.0 2>&1 | FileCheck --check-prefixes=ONE,BUF,NOBAR,NOBAZ %s
+
+# 'bar' can't be implied because it is exported
+# This also prevents implying the DSU, so 'baz' is silently not implied either
+# RUN: ld.lld --shared --verbose-c18n --compartment-policy=%t/one.json %t/one.o %t/two_hidden.o %t/three.o -o %t/implicit_bar_exported.so.0 2>&1 | FileCheck --check-prefixes=ONE,BUF,NOBAR %s
+
+# Hidden 'bar' and 'baz' can be implied
+# RUN: ld.lld --shared --verbose-c18n --compartment-policy=%t/one.json %t/one.o %t/two_hidden.o %t/three_hidden.o -o %t/implicit_bar_baz.so.0 2>&1 | FileCheck --check-prefixes=ONE,BUF,BAR %s
+
+# Exported 'bar' in separate compartment blocks implicit 'baz'
+# RUN: ld.lld --shared --verbose-c18n --compartment-policy=%t/two.json %t/one.o %t/two_hidden.o %t/three.o -o %t/implicit_two.so.0 2>&1 | FileCheck --check-prefixes=ONE,TWO,BUF %s
+
+# ONE: one.o:.text assigned to compartment one
+# TWO: three.o:.text assigned to compartment two
+# BUF: one.o:.data assigned to implied compartment one due to direct access of symbol buf
+# NOBAR: three.o:.text not assigned to implied compartment one due to exported symbol bar
+# NOBAZ: two.o:.data not assigned to implied compartment one due to exported symbol baz
+# BAZ: info: assigning disjoint set to compartment one:
+# BAZ-NEXT: two_hidden.o:.data
+# BAR: info: assigning disjoint set to compartment one:
+# BAR-NEXT: three_hidden.o:.text
+# BAR-NEXT: two_hidden.o:.data
+# TWO: info: disjoint set spans multiple compartments:
+# TWO-NEXT: one.o:.text from compartment one
+# TWO-NEXT: three.o:.text from compartment two
+# TWO-NEXT: two_hidden.o:.data from the default compartment
+
+#--- one.s
+
+	.text
+	.global	foo
+	.type	foo, @function
+foo:
+	cllc	ct0, buf
+	clgc	ct1, baz
+	ret
+	.size	foo, . - foo
+
+	.data
+	.type	buf, @object
+buf:
+	.space 1024
+	.size	buf, . - buf
+
+#--- two.s
+
+	.data
+	.global	baz
+	.type	baz, @object
+baz:
+	.space 1024
+	.size	baz, . - baz
+
+#--- two_hidden.s
+
+	.data
+	.global	baz
+	.hidden baz
+	.type	baz, @object
+baz:
+	.space 1024
+	.size	baz, . - baz
+
+#--- three.s
+
+	.text
+	.global	bar
+	.type	bar, @function
+bar:
+	clgc	ct0, baz
+	ret
+	.size	bar, . - bar
+
+#--- three_hidden.s
+
+	.text
+	.global	bar
+	.hidden	bar
+	.type	bar, @function
+bar:
+	clgc	ct0, baz
+	ret
+	.size	bar, . - bar
+
+#--- one.json
+
+{
+    "compartments": {
+	"one": { "symbols": ["foo"] }
+    }
+}
+
+#--- two.json
+
+{
+    "compartments": {
+	"one": { "symbols": ["foo"] },
+	"two": { "symbols": ["bar"] }
+    }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/invalid_pcrel.s
+++ b/lld/test/ELF/cheri/riscv/c18n/invalid_pcrel.s
@@ -1,0 +1,36 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/two.s -o %t/two.o
+# RUN: not ld.lld --shared --compartment-policy=%t/compartments.json %t/one.o %t/two.o -o %t/invalid_pcrel.so.0 2>&1 | FileCheck  %s
+
+# CHECK: error: symbol bar assigned to compartment two is directly accessed by compartment one
+
+#--- one.s
+
+	.text
+	.global	foo
+	.type	foo, @function
+foo:
+	cllc	ct0, bar
+	ret
+	.size	foo, . - foo
+
+#--- two.s
+
+	.text
+	.global	bar
+	.type	bar, @function
+bar:
+	ret
+	.size	bar, . - bar
+
+#--- compartments.json
+
+{
+    "compartments": {
+	"one": { "symbols": ["foo"] },
+	"two": { "symbols": ["bar"] }
+    }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/libcrosscall.s
+++ b/lld/test/ELF/cheri/riscv/c18n/libcrosscall.s
@@ -1,0 +1,114 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/dice.s -o %t/dice.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/two.s -o %t/two.o
+# RUN: ld.lld --shared --compartment-policy=%t/compartments.json %t/dice.o %t/one.o %t/two.o -o %t/libcrosscall.so.0
+
+# RUN: llvm-readelf -t %t/libcrosscall.so.0 | FileCheck --check-prefix=SECTIONS %s
+# RUN: llvm-readelf -s %t/libcrosscall.so.0 | FileCheck --check-prefix=SYMBOLS %s
+# RUN: llvm-readelf --cap-relocs %t/libcrosscall.so.0 | FileCheck --check-prefix=CAPRELOCS %s
+# RUN: llvm-objdump -d %t/libcrosscall.so.0 | FileCheck --check-prefix=DISASM %s
+
+# SECTIONS-LABEL: Section Headers:
+# SECTIONS:	  [ 8] .text.one
+# SECTIONS:	  [ 9] .got.one
+# SECTIONS:	  [11] .text.two
+# SECTIONS:	  [12] .iplt.two
+# SECTIONS-NEXT:      PROGBITS        0000000000004630
+# SECTIONS:	  [13] .got.plt.two
+
+# SYMBOLS-LABEL: Symbol table '.symtab'
+# SYMBOLS:	    3: 0000000000002590     8 FUNC    LOCAL  HIDDEN      8 dice_roll
+# SYMBOLS:	    5: 0000000000002598    44 FUNC    GLOBAL DEFAULT     8 one_value
+# SYMBOLS-NEXT:     6: 00000000000025c4    12 FUNC    GLOBAL DEFAULT     8 one_func
+# SYMBOLS-NEXT:     7: 00000000000045f0    44 FUNC    GLOBAL DEFAULT    11 two_value
+# SYMBOLS-NEXT:     8: 000000000000461c    12 FUNC    GLOBAL DEFAULT    11 two_func
+
+# CAPRELOCS-LABEL: CHERI capability relocation section '__cap_relocs' at offset {{.+}} contains 2 entries:
+# CAPRELOCS-NEXT:      Offset             Info         Type        Value
+# CAPRELOCS-NEXT:  00000000000035e0  8000000000000000 FUNC    0000000000002590 [0000000000002590-00000000000035f0]
+# CAPRELOCS-NEXT:  0000000000005640  8000000000000000 FUNC    0000000000002590 [0000000000002590-00000000000035f0]
+
+# one_value() should call dice_roll() directly
+# 0x25a8 - 24 == 0x2590 (dice_roll)
+# DISASM-LABEL: 0000000000002598 <one_value>:
+# DISASM:	     25a8: 97 00 00 00   auipcc  cra, 0
+# DISASM-NEXT:	     25ac: e7 80 80 fe   jalr    -24(cra)
+
+# two_value() should branch to the IPLT entry
+# 0x4600 + 48 == 0x4630 (.iplt.two)
+# DISASM-LABEL: 00000000000045f0 <two_value>:
+# DISASM:	     4600: 97 00 00 00   auipcc  cra, 0
+# DISASM-NEXT:	     4604: e7 80 00 03   jalr    48(cra)
+
+#--- dice.s
+
+	.text
+	.global	dice_roll
+	.type	dice_roll, @function
+	.hidden	dice_roll
+dice_roll:
+	li	a0, 4
+	ret
+	.size	dice_roll, . - dice_roll
+
+#--- one.s
+
+	.text
+	.global	one_value
+	.type	one_value, @function
+one_value:
+	cincoffset	csp, csp, -32
+	sc	cra, 16(csp)
+	sc	cs0, 0(csp)
+	mv	s0, a0
+	ccall	dice_roll
+	addw	a0, a0, s0
+	lc	cra, 16(csp)
+	lc	cs0, 0(csp)
+	cincoffset	csp, csp, 32
+	ret
+	.size	one_value, . - one_value
+
+	.global	one_func
+	.type	one_func, @function
+one_func:
+	clgc	ca0, dice_roll
+	ret
+	.size	one_func, . - one_func
+
+#--- two.s
+
+	.text
+	.global	two_value
+	.type	two_value, @function
+two_value:
+	cincoffset	csp, csp, -32
+	sc	cra, 16(csp)
+	sc	cs0, 0(csp)
+	mv	s0, a0
+	ccall	dice_roll
+	or	a0, a0, s0
+	lc	cra, 16(csp)
+	lc	cs0, 0(csp)
+	cincoffset	csp, csp, 32
+	ret
+	.size	two_value, . - two_value
+
+	.global	two_func
+	.type	two_func, @function
+two_func:
+	clgc	ca0, dice_roll
+	ret
+	.size	two_func, . - two_func
+
+#--- compartments.json
+
+{
+    "compartments": {
+	"one": { "files": ["one.o", "dice.o"] },
+	"two": { "files": ["two.o"] }
+    }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/libcrossfptr.s
+++ b/lld/test/ELF/cheri/riscv/c18n/libcrossfptr.s
@@ -1,0 +1,69 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/dice.s -o %t/dice.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/two.s -o %t/two.o
+# RUN: ld.lld --shared --compartment-policy=%t/compartments.json %t/dice.o %t/one.o %t/two.o -o %t/libcrossfptr.so.0
+
+# RUN: llvm-readelf -t %t/libcrossfptr.so.0 | FileCheck --check-prefix=SECTIONS %s
+# RUN: llvm-readelf -s %t/libcrossfptr.so.0 | FileCheck --check-prefix=SYMBOLS %s
+# RUN: llvm-readelf --cap-relocs %t/libcrossfptr.so.0 | FileCheck --check-prefix=CAPRELOCS %s
+
+# SECTIONS-LABEL: Section Headers:
+# SECTIONS:	  [ 8] .text.one
+# SECTIONS:	  [ 9] .got.one
+# SECTIONS-NEXT:       PROGBITS        0000000000003580
+# SECTIONS:	  [11] .text.two
+# SECTIONS:	  [12] .got.two
+# SECTIONS-NEXT:       PROGBITS        00000000000055b0
+
+# SYMBOLS-LABEL: Symbol table '.symtab'
+# SYMBOLS:	    3: 0000000000002568     8 FUNC    LOCAL  HIDDEN      8 dice_roll
+# SYMBOLS:          5: 0000000000002570    12 FUNC    GLOBAL DEFAULT     8 one_func
+# SYMBOLS-NEXT:     6: 00000000000045a0    12 FUNC    GLOBAL DEFAULT    11 two_func
+
+# CAPRELOCS-LABEL: CHERI capability relocation section '__cap_relocs' at offset {{.+}} contains 2 entries:
+# CAPRELOCS-NEXT:      Offset             Info         Type        Value
+# CAPRELOCS-NEXT:  0000000000003590  8000000000000000 FUNC    0000000000002568 [0000000000002568-00000000000035a0]
+# CAPRELOCS-NEXT:  00000000000055c0  8000000000000000 FUNC    0000000000002568 [0000000000002568-00000000000035a0]
+
+#--- dice.s
+
+	.text
+	.global	dice_roll
+	.type	dice_roll, @function
+	.hidden	dice_roll
+dice_roll:
+	li	a0, 4
+	ret
+	.size	dice_roll, . - dice_roll
+
+#--- one.s
+
+	.text
+	.global	one_func
+	.type	one_func, @function
+one_func:
+	clgc	ca0, dice_roll
+	ret
+	.size	one_func, . - one_func
+
+#--- two.s
+
+	.text
+	.global	two_func
+	.type	two_func, @function
+two_func:
+	clgc	ca0, dice_roll
+	ret
+	.size	two_func, . - two_func
+
+#--- compartments.json
+
+{
+    "compartments": {
+	"one": { "files": ["one.o", "dice.o"] },
+	"two": { "files": ["two.o"] }
+    }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/libmulti.s
+++ b/lld/test/ELF/cheri/riscv/c18n/libmulti.s
@@ -1,0 +1,206 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/oneb.s -o %t/oneb.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/two.s -o %t/two.o
+# RUN: ld.lld --shared --compartment-policy=%t/compartments.json %t/one.o %t/oneb.o %t/two.o -o %t/libmulti.so.0
+
+# RUN: llvm-readelf -t %t/libmulti.so.0 | FileCheck --check-prefix=SECTIONS %s
+# RUN: llvm-readelf -l %t/libmulti.so.0 | FileCheck --check-prefix=SEGMENTS %s
+# RUN: llvm-readelf -s %t/libmulti.so.0 | FileCheck --check-prefix=SYMBOLS %s
+# RUN: llvm-readelf -d %t/libmulti.so.0 | FileCheck --check-prefix=DYNAMIC %s
+
+# Using multiple policy files
+# RUN: ld.lld --shared --compartment-policy=%t/one.json --compartment-policy=%t/two.json %t/one.o %t/oneb.o %t/two.o -o %t/libmulti_multi.so.0
+
+# RUN: llvm-readelf -t %t/libmulti_multi.so.0 | FileCheck --check-prefix=SECTIONS %s
+# RUN: llvm-readelf -l %t/libmulti_multi.so.0 | FileCheck --check-prefix=SEGMENTS %s
+# RUN: llvm-readelf -s %t/libmulti_multi.so.0 | FileCheck --check-prefix=SYMBOLS %s
+# RUN: llvm-readelf -d %t/libmulti_multi.so.0 | FileCheck --check-prefix=DYNAMIC %s
+
+# SECTIONS-LABEL: Section Headers:
+# SECTIONS:	[ 6] .c18nstrtab
+# SECTIONS:	[10] .text.one
+# SECTIONS:	[11] .got.one
+# SECTIONS:	[12] .pad.cheri.pcc.one
+# SECTIONS:	[13] .bss.one
+# SECTIONS:	[14] .rela.plt.two
+# SECTIONS:	[15] .rodata.two
+# SECTIONS:	[16] .text.two
+# SECTIONS:	[17] .plt.two
+# SECTIONS:	[18] .got.two
+# SECTIONS:	[19] .got.plt.two
+# SECTIONS:	[20] .pad.cheri.pcc.two
+
+# SEGMENTS:	There are 20 program headers, starting at offset 64
+
+# SEGMENTS-LABEL: Program Headers:
+# SEGMENTS-NEXT:    Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
+# SEGMENTS-NEXT:    PHDR           0x000040 0x0000000000000040 0x0000000000000040 0x000460 0x000460 R   0x8
+# SEGMENTS-NEXT:    LOAD           0x000000 0x0000000000000000 0x0000000000000000 0x000700 0x000700 R   0x1000
+# SEGMENTS-NEXT:    LOAD           0x000700 0x0000000000001700 0x0000000000001700 0x000120 0x000120 RW  0x1000
+# SEGMENTS-NEXT:    LOAD           0x000820 0x0000000000002820 0x0000000000002820 0x000040 0x000040 R E 0x1000
+# SEGMENTS-NEXT:    LOAD           0x000860 0x0000000000003860 0x0000000000003860 0x000020 0x000020 RW  0x1000
+# SEGMENTS-NEXT:    LOAD           0x000880 0x0000000000004880 0x0000000000004880 0x000000 0x000004 RW  0x1000
+# SEGMENTS-NEXT:    LOAD           0x000888 0x0000000000005888 0x0000000000005888 0x00003e 0x00003e R   0x1000
+# SEGMENTS-NEXT:    LOAD           0x0008c8 0x00000000000068c8 0x00000000000068c8 0x000098 0x000098 R E 0x1000
+# SEGMENTS-NEXT:    LOAD           0x000960 0x0000000000007960 0x0000000000007960 0x000040 0x000040 RW  0x1000
+# SEGMENTS-NEXT:    LOAD           0x0009a0 0x00000000000089a0 0x00000000000089a0 0x000040 0x000040 RW  0x1000
+# SEGMENTS-NEXT:    TLS            0x000700 0x0000000000000700 0x0000000000000700 0x000000 0x000080 R   0x1
+# SEGMENTS-NEXT:    DYNAMIC        0x000700 0x0000000000001700 0x0000000000001700 0x000120 0x000120 RW  0x8
+# SEGMENTS-NEXT:    C18N_NAME      0x000820 0x0000000000002820 0x0000000000000001 0x000060 0x002064     0x10
+# SEGMENTS-NEXT:        [Compartment: one]
+# SEGMENTS-NEXT:    C18N_NAME      0x000888 0x0000000000005888 0x0000000000000005 0x000158 0x003158     0x10
+# SEGMENTS-NEXT:        [Compartment: two]
+# SEGMENTS-NEXT:    GNU_RELRO      0x000700 0x0000000000001700 0x0000000000001700 0x000120 0x000900 R   0x1
+# SEGMENTS-NEXT:    GNU_RELRO      0x000860 0x0000000000003860 0x0000000000003860 0x000020 0x0007a0 R   0x1
+# SEGMENTS-NEXT:    GNU_RELRO      0x000960 0x0000000000007960 0x0000000000007960 0x000040 0x0006a0 R   0x1
+# SEGMENTS-NEXT:    CHERI_PCC      0x000820 0x0000000000002820 0x0000000000002820 0x000060 0x001060 R E 0x10
+# SEGMENTS-NEXT:    CHERI_PCC      0x0008c0 0x00000000000058c0 0x00000000000058c0 0x000120 0x003120 R E 0x10
+# SEGMENTS-NEXT:    GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RW  0x0
+
+# SEGMENTS-LABEL: Section to Segment mapping:
+# SEGMENTS-NEXT:  Segment Sections...
+# SEGMENTS-NEXT:   00
+# SEGMENTS-NEXT:   01     .dynsym .gnu.hash .hash .dynstr .rela.dyn .c18nstrtab  __cap_relocs
+# SEGMENTS-NEXT:   02     .dynamic
+# SEGMENTS-NEXT:   03     .text.one
+# SEGMENTS-NEXT:   04     .got.one
+# SEGMENTS-NEXT:   05     .bss.one
+# SEGMENTS-NEXT:   06     .rela.plt.two
+# SEGMENTS-NEXT:   07     .text.two .plt.two
+# SEGMENTS-NEXT:   08     .got.two
+# SEGMENTS-NEXT:   09     .got.plt.two
+# SEGMENTS-NEXT:   10     .tbss
+# SEGMENTS-NEXT:   11     .dynamic
+# SEGMENTS-NEXT:   12     .text.one .got.one .bss.one
+# SEGMENTS-NEXT:   13     .rela.plt.two .rodata.two .text.two .plt.two .got.two .got.plt.two
+# SEGMENTS-NEXT:   14     .dynamic
+# SEGMENTS-NEXT:   15     .got.one
+# SEGMENTS-NEXT:   16     .got.two
+# SEGMENTS-NEXT:   17     .text.one .got.one
+# SEGMENTS-NEXT:   18     .rodata.two .text.two .plt.two .got.two .got.plt.two
+# SEGMENTS-NEXT:   19
+# SEGMENTS-NEXT:   None   .pad.cheri.pcc.one .pad.cheri.pcc.two .comment .symtab .shstrtab .strtab
+
+# SYMBOLS-LABEL: Symbol table '.dynsym'
+# SYMBOLS:	 3: 0000000000002820    16 FUNC    GLOBAL DEFAULT    10 set_counter
+# SYMBOLS-NEXT:  4: 0000000000002830    24 FUNC    GLOBAL DEFAULT    10 increment_counter
+# SYMBOLS-NEXT:  5: 0000000000002848    24 FUNC    GLOBAL DEFAULT    10 decrement_counter
+# SYMBOLS-NEXT:  6: 00000000000068c8    84 FUNC    GLOBAL DEFAULT    16 counter_str
+
+# SYMBOLS-LABEL: Symbol table '.symtab'
+# SYMBOLS:	 3: 0000000000004880     4 OBJECT  LOCAL  HIDDEN     13 counter
+# SYMBOLS:	 5: 0000000000000000   128 TLS     LOCAL  DEFAULT     8 counter_buffer
+
+# DYNAMIC-LABEL: Dynamic section
+# DYNAMIC:	 0x0000000000000017 (JMPREL)                    0x5888
+# DYNAMIC-NEXT:  0x0000000000000002 (PLTRELSZ)                  48 (bytes)
+# DYNAMIC-NEXT:  0x0000000000000003 (PLTGOT)                    0x89a0
+# DYNAMIC-NEXT:  0x0000000000000014 (PLTREL)                    RELA
+
+#--- one.s
+
+	.bss
+	.global counter
+	.type	counter, @object
+	.hidden	counter
+counter:
+	.zero	4
+	.size	counter, 4
+
+	.text
+	.global set_counter
+	.type	set_counter, @function
+set_counter:
+	clgc	ca1, counter
+	sw	a0, 0(ca1)
+	ret
+	.size	set_counter, . - set_counter
+
+	.text
+	.global increment_counter
+	.type	increment_counter, @function
+increment_counter:
+	clgc	ca1, counter
+	lw	a2, 0(ca1)
+	addw	a2, a2, a0
+	sw	a2, 0(ca1)
+	ret
+	.size	increment_counter, . - increment_counter
+
+#--- oneb.s
+
+	.text
+	.global decrement_counter
+	.type	decrement_counter, @function
+decrement_counter:
+	clgc	ca1, counter
+	lw	a2, 0(ca1)
+	subw	a2, a2, a0
+	sw	a2, 0(ca1)
+	ret
+	.size	decrement_counter, . - decrement_counter
+
+#--- two.s
+
+	.section	.tbss,"awT",@nobits
+	.type	counter_buffer, @object
+counter_buffer:
+	.zero	128
+	.size	counter_buffer, 128
+
+	.rodata
+	.type	fmt,@object
+fmt:
+	.asciz	"%s:%d"
+	.size	fmt, . - fmt
+
+	.text
+	.global counter_str
+	.type	counter_str, @function
+counter_str:
+	cincoffset	csp, csp, -64
+	sc	cra, 48(csp)
+	sc	ca0, 0(csp)
+1:	auipcc	ca0, %tls_gd_pcrel_hi(counter_buffer)
+	cincoffset	ca0, ca0, %pcrel_lo(1b)
+	ccall	__tls_get_addr
+	sc	ca0, 32(csp)
+	clgc	ca1, counter
+	lw	a1, 0(ca1)
+	sd	a1, 16(csp)
+	clgc	ca2, fmt
+	li	a1, 128
+	ccall	snprintf
+	lc	cra, 48(csp)
+	lc	ca0, 32(csp)
+	cincoffset	csp, csp, 64
+	ret
+	.size	counter_str, . - counter_str
+
+#--- compartments.json
+
+{
+    "compartments": {
+	"one": { "files": ["one.*o", "oneb.*o"] },
+	"two": { "files": [], "symbols": ["counter_str"] }
+    }
+}
+
+#--- one.json
+
+{
+    "compartments": {
+	"one": { "files": ["one.*o", "oneb.*o"] }
+    }
+}
+
+#--- two.json
+
+{
+    "compartments": {
+	"two": { "symbols": ["counter_str"] }
+    }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/merge_section_got.s
+++ b/lld/test/ELF/cheri/riscv/c18n/merge_section_got.s
@@ -3,9 +3,9 @@
 
 # RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
 # RUN: ld.lld --shared --compartment-policy=%t/compartments.json %t/one.o -o %t/merge_section_got.so
-# RUN: readelf -t %t/merge_section_got.so | FileCheck --check-prefix=SECTIONS %s
-# RUN: objdump -d --no-show-raw-insn %t/merge_section_got.so | FileCheck --check-prefix=DIS %s
-# RUN: readelf --cap-relocs %t/merge_section_got.so | FileCheck --check-prefix=CAP-RELOCS %s
+# RUN: llvm-readelf -t %t/merge_section_got.so | FileCheck --check-prefix=SECTIONS %s
+# RUN: llvm-objdump -d --no-show-raw-insn %t/merge_section_got.so | FileCheck --check-prefix=DIS %s
+# RUN: llvm-readelf --cap-relocs %t/merge_section_got.so | FileCheck --check-prefix=CAP-RELOCS %s
 
 # SECTIONS-LABEL: Section Headers:
 # SECTIONS:         [10] .rodata.one

--- a/lld/test/ELF/cheri/riscv/c18n/merge_section_got.s
+++ b/lld/test/ELF/cheri/riscv/c18n/merge_section_got.s
@@ -1,0 +1,83 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
+# RUN: ld.lld --shared --compartment-policy=%t/compartments.json %t/one.o -o %t/merge_section_got.so
+# RUN: readelf -t %t/merge_section_got.so | FileCheck --check-prefix=SECTIONS %s
+# RUN: objdump -d --no-show-raw-insn %t/merge_section_got.so | FileCheck --check-prefix=DIS %s
+# RUN: readelf --cap-relocs %t/merge_section_got.so | FileCheck --check-prefix=CAP-RELOCS %s
+
+# SECTIONS-LABEL: Section Headers:
+# SECTIONS:         [10] .rodata.one
+# SECTIONS-NEXT:         PROGBITS        0000000000003598 000598 000022 01   0   0  8
+# SECTIONS-NEXT:         [0000000000000032]: ALLOC, MERGE, STRINGS
+# SECTIONS-NEXT:    [11] .text.one
+# SECTIONS-NEXT:         PROGBITS        00000000000045bc 0005bc 00000c 00   0   0  4
+# SECTIONS-NEXT:         [0000000000000006]: ALLOC, EXEC
+# SECTIONS-NEXT:    [12] .pad.cheri.pcc.one
+# SECTIONS-NEXT:         PROGBITS        00000000000045c8 0005c8 000000 00   0   0  1
+# SECTIONS-NEXT:         [0000000000000006]: ALLOC, EXEC
+# SECTIONS-NEXT:    [13] .rodata.two
+# SECTIONS-NEXT:         PROGBITS        00000000000055d0 0005d0 000022 01   0   0  16
+# SECTIONS-NEXT:         [0000000000000032]: ALLOC, MERGE, STRINGS
+# SECTIONS-NEXT:    [14] .text.two
+# SECTIONS-NEXT:         PROGBITS        00000000000065f4 0005f4 00000c 00   0   0  4
+# SECTIONS-NEXT:         [0000000000000006]: ALLOC, EXEC
+# SECTIONS-NEXT:    [15] .got.two
+# SECTIONS-NEXT:         PROGBITS        0000000000007600 000600 000020 00   0   0  16
+# SECTIONS-NEXT:         [0000000000000003]: WRITE, ALLOC
+# SECTIONS-NEXT:    [16] .pad.cheri.pcc.two
+
+# DIS-LABEL: Disassembly of section .text.one:
+# DIS:       <foo>:
+## .Lfoo_str.one - . = 0x3598 - 0x45bc = 4096*-1 - 24
+# DIS-NEXT:  45bc:       auipcc  ct0, 1048575
+# DIS-NEXT:              cincoffset      ct0, ct0, -36
+
+# DIS-LABEL: Disassembly of section .text.two:
+# DIS:       <bar>:
+## .Lbar_str.two@got - . = 0x7610 - 0x65f4 = 4096*1 + 28
+# DIS-NEXT:  65f4:       auipcc  ct0, 1
+# DIS-NEXT:              lc      ct0, 28(ct0)
+
+# CAP-RELOCS:     Offset             Info         Type        Value
+# CAP-RELOCS: 0000000000007610  4000000000000000 RODATA  00000000000055e0 [00000000000055e0-00000000000055f2]
+
+#--- one.s
+
+	.section .text.foo,"ax",@progbits
+	.p2align 2
+	.global	foo
+	.type	foo, @function
+foo:
+	cllc	ct0, .Lfoo_str
+	ret
+	.size	foo, . - foo
+
+	.section .rodata.str1.1,"aMS",@progbits,1
+.Lfoo_str:
+	.asciz	"foo like grapes"
+	.size	.Lfoo_str, . - .Lfoo_str
+
+	.section .text.bar,"ax",@progbits
+	.p2align 2
+	.global	bar
+	.type	bar, @function
+bar:
+	clgc	ct0, .Lbar_str
+	ret
+	.size	bar, . - bar
+
+	.section .rodata.str1.1,"aMS",@progbits,1
+.Lbar_str:
+	.asciz	"bar likes oranges"
+	.size	.Lbar_str, . - .Lbar_str
+
+#--- compartments.json
+
+{
+    "compartments": {
+	"one": { "symbols": ["foo"] },
+	"two": { "symbols": ["bar"] }
+    }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/merge_section_special_symbols.s
+++ b/lld/test/ELF/cheri/riscv/c18n/merge_section_special_symbols.s
@@ -1,0 +1,74 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
+# RUN: ld.lld --shared --compartment-policy=%t/compartments.json %t/one.o -o %t/merge_section_symbol.so
+# RUN: readelf -t %t/merge_section_symbol.so | FileCheck --check-prefix=SECTIONS %s
+# RUN: objdump -d --no-show-raw-insn %t/merge_section_symbol.so | FileCheck --check-prefix=DIS %s
+
+# SECTIONS-LABEL: Section Headers:
+# SECTIONS:         [ 9] .rodata.one
+# SECTIONS-NEXT:         PROGBITS        00000000000034c0 0004c0 000008 04   0   0  8
+# SECTIONS-NEXT:         [0000000000000012]: ALLOC, MERGE
+# SECTIONS:         [12] .rodata.two
+# SECTIONS-NEXT:         PROGBITS        00000000000054d8 0004d8 000008 04   0   0  8
+# SECTIONS-NEXT:         [0000000000000012]: ALLOC, MERGE
+
+# DIS-LABEL: Disassembly of section .text.one:
+# DIS:       <foo>:
+## .Lfoo_data.one - . = 0x34c0 - 0x44c8 = 4096*-1 - 8
+# DIS-NEXT:  44c8:       auipcc  ct0, 1048575
+# DIS-NEXT:              cincoffset      ct0, ct0, -8
+
+# DIS-LABEL: Disassembly of section .text.two:
+# DIS:       <bar>:
+## .Lbar_data.two - . = 0x64e0 - 0x54dc = 4096*-1 - 4
+# DIS-NEXT:  64e0:       auipcc  ct0, 1048575
+# DIS-NEXT:              cincoffset      ct0, ct0, -4
+## .rodata.two - . = 0x64e8 - 0x54d8 = 4096*-1 - 16
+# DIS:       64e8:       auipcc  ct1, 1048575
+# DIS-NEXT:              cincoffset      ct1, ct1, -16
+
+#--- one.s
+
+	.section .text.foo,"ax",@progbits
+	.p2align 2
+	.global	foo
+	.type	foo, @function
+foo:
+	cllc	ct0, .Lfoo_data
+	ret
+	.size	foo, . - foo
+
+	.section .rodata.cst4,"aM",@progbits,4
+	.p2align 2
+$d.0:
+.Lfoo_data:
+	.word	0x1234
+	.size	.Lfoo_data, . - .Lfoo_data
+
+	.section .text.bar,"ax",@progbits
+	.p2align 2
+	.global	bar
+	.type	bar, @function
+bar:
+	cllc	ct0, .Lbar_data
+	cllc	ct1, .rodata.cst4
+	ret
+	.size	bar, . - bar
+
+	.section .rodata.cst4,"aM",@progbits,4
+	.p2align 2
+$d.1:
+.Lbar_data:
+	.word	0x5678
+	.size	.Lbar_data, . - .Lbar_data
+
+#--- compartments.json
+
+{
+    "compartments": {
+	"one": { "symbols": ["foo"] },
+	"two": { "symbols": ["bar"] }
+    }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/merge_section_special_symbols.s
+++ b/lld/test/ELF/cheri/riscv/c18n/merge_section_special_symbols.s
@@ -3,8 +3,8 @@
 
 # RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
 # RUN: ld.lld --shared --compartment-policy=%t/compartments.json %t/one.o -o %t/merge_section_symbol.so
-# RUN: readelf -t %t/merge_section_symbol.so | FileCheck --check-prefix=SECTIONS %s
-# RUN: objdump -d --no-show-raw-insn %t/merge_section_symbol.so | FileCheck --check-prefix=DIS %s
+# RUN: llvm-readelf -t %t/merge_section_symbol.so | FileCheck --check-prefix=SECTIONS %s
+# RUN: llvm-objdump -d --no-show-raw-insn %t/merge_section_symbol.so | FileCheck --check-prefix=DIS %s
 
 # SECTIONS-LABEL: Section Headers:
 # SECTIONS:         [ 9] .rodata.one

--- a/lld/test/ELF/cheri/riscv/c18n/no_default.s
+++ b/lld/test/ELF/cheri/riscv/c18n/no_default.s
@@ -1,0 +1,54 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/two.s -o %t/two.o
+# RUN: not ld.lld --shared --no-default-compartment %t/one.o %t/two.o -o %t/no_default.so.0 2>&1 | FileCheck -check-prefixes=ONE,TWO %s
+# RUN: not ld.lld --shared --compartment-policy=%t/empty.json --no-default-compartment %t/one.o %t/two.o -o %t/no_default.so.0 2>&1 | FileCheck -check-prefixes=ONE,TWO %s
+# RUN: not ld.lld --shared --compartment-policy=%t/one.json --no-default-compartment %t/one.o %t/two.o -o %t/no_default.so.0 2>&1 | FileCheck -check-prefix=TWO %s
+# RUN: ld.lld --shared --compartment-policy=%t/both.json --no-default-compartment %t/one.o %t/two.o -o %t/no_default.so.0
+
+# ONE: ld.lld: error: input section {{.*}}one.o:.text not assigned to a compartment
+# TWO: ld.lld: error: input section {{.*}}two.o:.text not assigned to a compartment
+
+#--- one.s
+
+	.text
+	.global	foo
+	.type	foo, @function
+foo:
+	ret
+	.size	foo, . - foo
+
+#--- two.s
+
+	.text
+	.global	bar
+	.type	bar, @function
+bar:
+	ret
+	.size	bar, . - bar
+
+#--- empty.json
+
+{
+    "compartments": {
+    }
+}
+
+#--- one.json
+
+{
+    "compartments": {
+	"one": { "symbols": ["foo"] }
+    }
+}
+
+#--- both.json
+
+{
+    "compartments": {
+	"one": { "symbols": ["foo"] },
+	"two": { "symbols": ["bar"] }
+    }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/relro.s
+++ b/lld/test/ELF/cheri/riscv/c18n/relro.s
@@ -1,0 +1,52 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
+# RUN: ld.lld --compartment-policy=%t/compartments.json %t/one.o -o %t/one
+# RUN: llvm-readelf -l %t/one | FileCheck %s
+
+## Verify that .data.rel.ro is treated as relro even with a compartment suffix.
+## Must be covered by a GNU_RELRO and included in CHERI_PCC.
+
+# CHECK-LABEL: Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
+# CHECK-NEXT:  PHDR           0x000040 0x0000000000010040 0x0000000000010040 0x0001c0 0x0001c0 R   0x8
+# CHECK-NEXT:  LOAD           0x000000 0x0000000000010000 0x0000000000010000 0x000205 0x000205 R   0x1000
+# CHECK-NEXT:  LOAD           0x000208 0x0000000000011208 0x0000000000011208 0x000008 0x000008 R E 0x1000
+# CHECK-NEXT:  LOAD           0x000210 0x0000000000012210 0x0000000000012210 0x000008 0x000008 RW  0x1000
+# CHECK-NEXT:  C18N_NAME      0x000208 0x0000000000011208 0x0000000000000001 0x000010 0x001010     0x4
+# CHECK-NEXT:      [Compartment: one]
+# CHECK-NEXT:  GNU_RELRO      0x000210 0x0000000000012210 0x0000000000012210 0x000008 0x000df0 R   0x1
+# CHECK-NEXT:  CHERI_PCC      0x000208 0x0000000000011208 0x0000000000011208 0x000010 0x001010 R E 0x8
+# CHECK-NEXT:  GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RW  0x0
+# CHECK-EMPTY:
+# CHECK-NEXT: Section to Segment mapping:
+# CHECK-NEXT:  Segment Sections...
+# CHECK-NEXT:   00
+# CHECK-NEXT:   01     .c18nstrtab
+# CHECK-NEXT:   02     .text.one
+# CHECK-NEXT:   03     .data.rel.ro.one .pad.cheri.pcc.one
+# CHECK-NEXT:   04     .text.one .data.rel.ro.one .pad.cheri.pcc.one
+# CHECK-NEXT:   05     .data.rel.ro.one .pad.cheri.pcc.one
+# CHECK-NEXT:   06     .text.one .data.rel.ro.one .pad.cheri.pcc.one
+# CHECK-NEXT:   07
+# CHECK-NEXT:   None   .comment .symtab .shstrtab .strtab
+
+
+#--- one.s
+
+cllc ca0, foo
+
+.data.rel.ro
+.type foo, %object
+foo: .byte 42
+.size foo, . - foo
+
+#--- compartments.json
+
+{
+  "compartments": {
+    "one": {
+      "files": ["one.o"]
+    }
+  }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/shared_merge_sections.s
+++ b/lld/test/ELF/cheri/riscv/c18n/shared_merge_sections.s
@@ -1,0 +1,83 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
+# RUN: ld.lld --shared --compartment-policy=%t/compartments.json %t/one.o -o %t/shared_merge_sections.so
+# RUN: ld.lld --gc-sections --shared --compartment-policy=%t/compartments.json %t/one.o -o %t/shared_merge_sections_gc.so
+# RUN: readelf -t %t/shared_merge_sections.so | FileCheck --check-prefix=SECTIONS %s
+# RUN: readelf -t %t/shared_merge_sections_gc.so | FileCheck --check-prefix=SECTIONS-GC %s
+# RUN: objdump -s -j .rodata %t/shared_merge_sections.so | FileCheck --check-prefix=RODATA %s
+# RUN: objdump -s -j .rodata.one %t/shared_merge_sections.so | FileCheck --check-prefix=RODATA %s
+# RUN: objdump -s -j .rodata.two %t/shared_merge_sections.so | FileCheck --check-prefix=RODATA %s
+# RUN: objdump -s -j .rodata.one %t/shared_merge_sections_gc.so | FileCheck --check-prefix=RODATA-ONE %s
+# RUN: objdump -s -j .rodata.two %t/shared_merge_sections_gc.so | FileCheck --check-prefix=RODATA-TWO %s
+
+# SECTIONS-LABEL: Section Headers:
+# SECTIONS:         [ 6] .rodata
+# SECTIONS-NEXT:         PROGBITS        0000000000000428 000428 000008 04   0   0  4
+# SECTIONS-NEXT:         [0000000000000012]: ALLOC, MERGE
+# SECTIONS:         [ 9] .rodata.one
+# SECTIONS-NEXT:         PROGBITS        00000000000034c0 0004c0 000008 04   0   0  8
+# SECTIONS-NEXT:         [0000000000000012]: ALLOC, MERGE
+# SECTIONS:         [12] .rodata.two
+# SECTIONS-NEXT:         PROGBITS        00000000000054d8 0004d8 000008 04   0   0  8
+# SECTIONS-NEXT:         [0000000000000012]: ALLOC, MERGE
+
+# SECTIONS-GC-LABEL: Section Headers:
+# SECTIONS-GC-NOT:   .rodata
+# SECTIONS-GC:         [ 7] .rodata.one
+# SECTIONS-GC-NEXT:         PROGBITS        0000000000002480 000480 000004 04   0   0  8
+# SECTIONS-GC-NEXT:         [0000000000000012]: ALLOC, MERGE
+# SECTIONS-GC:         [10] .rodata.two
+# SECTIONS-GC-NEXT:         PROGBITS        0000000000004490 000490 000004 04   0   0  8
+# SECTIONS-GC-NEXT:         [0000000000000012]: ALLOC, MERGE
+
+# RODATA-LABEL: Contents of section .rodata
+# RODATA-NEXT:     34120000 78560000                    4...xV..
+
+# RODATA-ONE-LABEL: Contents of section .rodata.one:
+# RODATA-ONE-NEXT: 34120000                             4...
+
+# RODATA-TWO-LABEL: Contents of section .rodata.two:
+# RODATA-TWO-NEXT: 78560000                             xV..
+
+#--- one.s
+
+	.section .text.foo,"ax",@progbits
+	.p2align 2
+	.global	foo
+	.type	foo, @function
+foo:
+	cllc	ct0, .Lfoo_data
+	ret
+	.size	foo, . - foo
+
+	.section .rodata.cst4,"aM",@progbits,4
+	.p2align 2
+.Lfoo_data:
+	.word	0x1234
+	.size	.Lfoo_data, . - .Lfoo_data
+
+	.section .text.bar,"ax",@progbits
+	.p2align 2
+	.global	bar
+	.type	bar, @function
+bar:
+	cllc	ct0, .Lbar_data
+	ret
+	.size	bar, . - bar
+
+	.section .rodata.cst4,"aM",@progbits,4
+	.p2align 2
+.Lbar_data:
+	.word	0x5678
+	.size	.Lbar_data, . - .Lbar_data
+
+#--- compartments.json
+
+{
+    "compartments": {
+	"one": { "symbols": ["foo"] },
+	"two": { "symbols": ["bar"] }
+    }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/shared_merge_sections.s
+++ b/lld/test/ELF/cheri/riscv/c18n/shared_merge_sections.s
@@ -4,13 +4,13 @@
 # RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/one.s -o %t/one.o
 # RUN: ld.lld --shared --compartment-policy=%t/compartments.json %t/one.o -o %t/shared_merge_sections.so
 # RUN: ld.lld --gc-sections --shared --compartment-policy=%t/compartments.json %t/one.o -o %t/shared_merge_sections_gc.so
-# RUN: readelf -t %t/shared_merge_sections.so | FileCheck --check-prefix=SECTIONS %s
-# RUN: readelf -t %t/shared_merge_sections_gc.so | FileCheck --check-prefix=SECTIONS-GC %s
-# RUN: objdump -s -j .rodata %t/shared_merge_sections.so | FileCheck --check-prefix=RODATA %s
-# RUN: objdump -s -j .rodata.one %t/shared_merge_sections.so | FileCheck --check-prefix=RODATA %s
-# RUN: objdump -s -j .rodata.two %t/shared_merge_sections.so | FileCheck --check-prefix=RODATA %s
-# RUN: objdump -s -j .rodata.one %t/shared_merge_sections_gc.so | FileCheck --check-prefix=RODATA-ONE %s
-# RUN: objdump -s -j .rodata.two %t/shared_merge_sections_gc.so | FileCheck --check-prefix=RODATA-TWO %s
+# RUN: llvm-readelf -t %t/shared_merge_sections.so | FileCheck --check-prefix=SECTIONS %s
+# RUN: llvm-readelf -t %t/shared_merge_sections_gc.so | FileCheck --check-prefix=SECTIONS-GC %s
+# RUN: llvm-objdump -s -j .rodata %t/shared_merge_sections.so | FileCheck --check-prefix=RODATA %s
+# RUN: llvm-objdump -s -j .rodata.one %t/shared_merge_sections.so | FileCheck --check-prefix=RODATA %s
+# RUN: llvm-objdump -s -j .rodata.two %t/shared_merge_sections.so | FileCheck --check-prefix=RODATA %s
+# RUN: llvm-objdump -s -j .rodata.one %t/shared_merge_sections_gc.so | FileCheck --check-prefix=RODATA-ONE %s
+# RUN: llvm-objdump -s -j .rodata.two %t/shared_merge_sections_gc.so | FileCheck --check-prefix=RODATA-TWO %s
 
 # SECTIONS-LABEL: Section Headers:
 # SECTIONS:         [ 6] .rodata

--- a/lld/test/ELF/cheri/riscv/c18n/static-lib.s
+++ b/lld/test/ELF/cheri/riscv/c18n/static-lib.s
@@ -1,0 +1,92 @@
+# REQUIRES: riscv
+
+# RUN: rm -rf %t && split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/a.s -o %t/a.o
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/b.s -o %t/b.o
+# RUN: llvm-ar crs %t/libb.a %t/b.o
+# RUN: ld.lld -o %t/scoped %t/a.o %t/libb.a \
+# RUN:   --compartment-policy=%t/scoped.json \
+# RUN:   --compartment-policy=%t/unscoped.json
+# RUN: ld.lld -o %t/unscoped %t/a.o %t/libb.a \
+# RUN:   --compartment-policy=%t/unscoped.json
+# RUN: llvm-readelf -l %t/scoped | FileCheck %s --check-prefix=SCOPED
+# RUN: llvm-readelf -l %t/unscoped | FileCheck %s --check-prefix=UNSCOPED
+
+# SCOPED-LABEL: Program Headers:
+# SCOPED-NEXT:    Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
+# SCOPED-NEXT:    PHDR           0x000040 0x0000000000010040 0x0000000000010040 0x0001f8 0x0001f8 R   0x8
+# SCOPED-NEXT:    LOAD           0x000000 0x0000000000010000 0x0000000000010000 0x000278 0x000278 R   0x1000
+# SCOPED-NEXT:    LOAD           0x000278 0x0000000000011278 0x0000000000011278 0x000028 0x000028 R E 0x1000
+# SCOPED-NEXT:    LOAD           0x0002a0 0x00000000000122a0 0x00000000000122a0 0x000010 0x000010 RW  0x1000
+# SCOPED-NEXT:    C18N_NAME      0x000278 0x0000000000011278 0x0000000000000001 0x000004 0x000004     0x4
+# SCOPED-NEXT:        [Compartment: scoped]
+# SCOPED-NEXT:    C18N_NAME      0x000280 0x0000000000011280 0x0000000000000008 0x000030 0x001030     0x10
+# SCOPED-NEXT:        [Compartment: unscoped]
+# SCOPED-NEXT:    CHERI_PCC      0x000278 0x0000000000011278 0x0000000000011278 0x000004 0x000004 R E 0x4
+# SCOPED-NEXT:    CHERI_PCC      0x000280 0x0000000000011280 0x0000000000011280 0x000030 0x001030 R E 0x10
+# SCOPED-NEXT:    GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RW  0x0
+
+# SCOPED-LABEL:  Section to Segment mapping:
+# SCOPED-NEXT:    Segment Sections...
+# SCOPED-NEXT:     00
+# SCOPED-NEXT:     01     .c18nstrtab __cap_relocs
+# SCOPED-NEXT:     02     .text.scoped .pad.cheri.pcc.scoped .text.unscoped .iplt.unscoped
+# SCOPED-NEXT:     03     .got.plt.unscoped
+# SCOPED-NEXT:     04     .text.scoped
+# SCOPED-NEXT:     05     .text.unscoped .iplt.unscoped .got.plt.unscoped
+# SCOPED-NEXT:     06     .text.scoped
+# SCOPED-NEXT:     07     .text.unscoped .iplt.unscoped .got.plt.unscoped
+# SCOPED-NEXT:     08
+# SCOPED-NEXT:     None   .pad.cheri.pcc.unscoped .comment .symtab .shstrtab .strtab
+
+# UNSCOPED-LABEL: Program Headers:
+# UNSCOPED-NEXT:    Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
+# UNSCOPED-NEXT:    PHDR           0x000040 0x0000000000010040 0x0000000000010040 0x000150 0x000150 R   0x8
+# UNSCOPED-NEXT:    LOAD           0x000000 0x0000000000010000 0x0000000000010000 0x00019a 0x00019a R   0x1000
+# UNSCOPED-NEXT:    LOAD           0x00019c 0x000000000001119c 0x000000000001119c 0x00000c 0x00000c R E 0x1000
+# UNSCOPED-NEXT:    C18N_NAME      0x00019c 0x000000000001119c 0x0000000000000001 0x00000c 0x00000c     0x4
+# UNSCOPED-NEXT:        [Compartment: unscoped]
+# UNSCOPED-NEXT:    CHERI_PCC      0x00019c 0x000000000001119c 0x000000000001119c 0x00000c 0x00000c R E 0x4
+# UNSCOPED-NEXT:    GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RW  0x0
+
+# UNSCOPED-LABEL:  Section to Segment mapping:
+# UNSCOPED-NEXT:    Segment Sections...
+# UNSCOPED-NEXT:     00
+# UNSCOPED-NEXT:     01     .c18nstrtab
+# UNSCOPED-NEXT:     02     .text.unscoped
+# UNSCOPED-NEXT:     03     .text.unscoped
+# UNSCOPED-NEXT:     04     .text.unscoped
+# UNSCOPED-NEXT:     05
+# UNSCOPED-NEXT:     None   .pad.cheri.pcc.unscoped .comment .symtab .shstrtab .strtab
+
+#--- a.s
+
+call foo
+
+#--- b.s
+
+.global foo
+.type foo, %function
+foo:
+  ret
+
+#--- scoped.json
+
+{
+  "compartments": {
+    "scoped": {
+      "files": ["libb.a:b.o"]
+    }
+  }
+}
+
+#--- unscoped.json
+
+{
+  "compartments": {
+    "unscoped": {
+      "files": ["a.o", "b.o"]
+    }
+  }
+}

--- a/lld/test/ELF/cheri/riscv/c18n/symbol-sections.s
+++ b/lld/test/ELF/cheri/riscv/c18n/symbol-sections.s
@@ -1,0 +1,49 @@
+# REQUIRES: riscv
+# RUN: split-file %s %t
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %t/a.s -o %t/a.o
+# RUN: ld.lld --shared -T %t/lds --compartment-policy=%t/compartments.json %t/a.o -o %t/liba.so
+# RUN: llvm-readelf -Ss %t/liba.so | FileCheck %s
+
+## Verify that, when using a linker script, sections not in the default
+## compartment get combined as if no linker script were present.
+
+# CHECK: {{\[ *}}[[#TEXT_ONE_IDX:]]{{\]}} .text.one PROGBITS [[#%.16x,TEXT_ONE_ADDR:]]
+# CHECK: {{\[ *}}[[#TEXT_TWO_IDX:]]{{\]}} .text.two PROGBITS [[#%.16x,TEXT_TWO_ADDR:]]
+
+# CHECK: [[#TEXT_ONE_ADDR]]   0 FUNC GLOBAL DEFAULT [[#TEXT_ONE_IDX]] foo
+# CHECK: [[#TEXT_ONE_ADDR+4]] 0 FUNC GLOBAL DEFAULT [[#TEXT_ONE_IDX]] bar
+# CHECK: [[#TEXT_TWO_ADDR]]   0 FUNC GLOBAL DEFAULT [[#TEXT_TWO_IDX]] baz
+
+#--- a.s
+
+.section .text.foo, "ax"
+.type foo, @function
+.global foo
+foo:
+  ret
+
+.section .text.bar, "ax"
+.type bar, @function
+.global bar
+bar:
+  ret
+
+.section .text.baz, "ax"
+.type baz, @function
+.global baz
+baz:
+  ret
+
+#--- lds
+
+SECTIONS {}
+
+#--- compartments.json
+
+{
+  "compartments": {
+    "one": { "symbols": ["foo", "bar"] },
+    "two": { "symbols": ["baz"] }
+  }
+}

--- a/lld/test/ELF/gnu-ifunc-plt-c18n.s
+++ b/lld/test/ELF/gnu-ifunc-plt-c18n.s
@@ -1,0 +1,107 @@
+// REQUIRES: x86
+// RUN: split-file %s %t
+
+/// Test references to non-preemptable ifuncs from both the same
+/// compartment and a foreign compartment.
+
+// RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %t/one.s -o %t/one.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %t/oneb.s -o %t/oneb.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %t/two.s -o %t/two.o
+
+// RUN: ld.lld --compartment-policy=%t/one.json %t/one.o %t/oneb.o -o %t/only_one.so
+// RUN: ld.lld --compartment-policy=%t/one.json --compartment-policy=%t/two.json %t/one.o %t/oneb.o %t/two.o -o %t/both.so
+// RUN: ld.lld --compartment-policy=%t/two.json --compartment-policy=%t/one.json %t/two.o %t/one.o %t/oneb.o -o %t/both_reverse.so
+// RUN: ld.lld --compartment-policy=%t/one.json --compartment-policy=%t/two.json %t/one.o %t/two.o -o %t/only_two.so
+
+// RUN: llvm-objdump -h -t -d %t/only_one.so | FileCheck --check-prefixes=CHECK,ONE %s
+// RUN: llvm-objdump -h -t -d %t/only_two.so | FileCheck --check-prefixes=CHECK,TWO %s
+// RUN: llvm-objdump -h -t -d %t/both.so | FileCheck --check-prefixes=CHECK,ONE,TWO %s
+// RUN: llvm-objdump -h -t -d %t/both_reverse.so | FileCheck --check-prefixes=CHECK,ONE %s
+// RUN: llvm-objdump -h -t -d %t/both_reverse.so | FileCheck --check-prefixes=CHECK,TWO %s
+
+// CHECK-LABEL: Sections:
+// CHECK-DAG: {{[0-9]+}} .iplt.one {{[0-9a-f]+}} [[#%.16x,FOO_ADDR:]] TEXT
+// TWO-DAG:   {{[0-9]+}} .iplt.two {{[0-9a-f]+}} [[#%.16x,IPLT_TWO_ADDR:]] TEXT
+
+// CHECK-LABEL: SYMBOL TABLE:
+// CHECK:     [[#%.16x,FOO_ADDR]] l     F .iplt.one      0000000000000000 .hidden foo
+
+// ONE-LABEL: Disassembly of section .text.one:
+// ONE: <one_call>:
+// ONE-NEXT: callq   0x[[#%x,FOO_ADDR]] <foo>
+// ONE-NEXT: retq
+
+// ONE: <one_value>:
+// ONE-NEXT: leaq    0x[[#%x,FOO_ADDR]], %rax
+// ONE-NEXT: retq
+
+// TWO-LABEL: Disassembly of section .text.two:
+// TWO: <two_call>:
+// TWO-NEXT: callq   0x[[#%x,IPLT_TWO_ADDR]]
+// TWO-NEXT: retq
+
+// TWO: <two_value>:
+// TWO-NEXT: leaq    0x[[#%x,FOO_ADDR]], %rax
+// TWO-NEXT: retq
+
+//--- one.s
+
+	.text
+	.global foo
+	.type	foo, STT_GNU_IFUNC
+	.hidden	foo
+foo:
+	ret
+	.size	foo, . - foo
+
+//--- oneb.s
+
+	.text
+	.global one_call
+	.type	one_call, @function
+one_call:
+	call	foo
+	ret
+	.size	one_call, . - one_call
+
+	.text
+	.global	one_value
+	.type	one_value, @function
+one_value:
+	lea	foo, %rax
+	ret
+	.size	one_value, . - one_value
+
+//--- two.s
+
+	.text
+	.global two_call
+	.type	two_call, @function
+two_call:
+	call	foo
+	ret
+	.size	two_call, . - two_call
+
+	.text
+	.global	two_value
+	.type	two_value, @function
+two_value:
+	lea	foo, %rax
+	ret
+	.size	two_value, . - two_value
+
+//--- one.json
+
+{
+    "compartments": {
+	"one": { "files": ["one*.o"] }
+    }
+}
+
+//--- two.json
+
+{
+    "compartments": {
+	"two": { "files": ["two.o"] }
+    }
+}


### PR DESCRIPTION
This allows for matching only input files pulled in from a static
library.

In theory extending this to support :(/path/to/)bar.o to mean only files
not from static libraries (i.e. on the command line or pulled in by
linker scripts) could be useful, but the priority of the various
combinations becomes less clear, as static libraries (by virtue of being
ar archives) don't permit directories and sidestep that question;
specifically, there is the question of whether :bar.o or /path/to/bar.o
(without an explicit empty scope) is higher priority.
