### PR TITLE
Various c18n_policy cleanups

### DIFF
--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -1046,9 +1046,9 @@ static bool alignPCCBounds(PhdrEntry *p, CheriPccPaddingSection &psec) {
 bool cheriCapabilityBoundsAlign() {
   // Align the PT_CHERI_PCC segment.
   bool changed = false;
-  for (Compartment &compart : compartments)
-    if (compart.cheriBounds)
-      changed |= alignPCCBounds(compart.cheriBounds, *compart.pccPadding);
+  for (Compartment &c : compartments)
+    if (c.cheriBounds)
+      changed |= alignPCCBounds(c.cheriBounds, *c.pccPadding);
   return changed;
 }
 

--- a/lld/ELF/Compartments.cpp
+++ b/lld/ELF/Compartments.cpp
@@ -213,9 +213,9 @@ static void addCompartment(StringRef name) {
 static Compartment *findCompartment(StringRef name) {
   if (name.empty())
     return defaultCompart;
-  for (Compartment &compart : compartments) {
-    if (compart.name.compare(name) == 0)
-      return &compart;
+  for (Compartment &c : compartments) {
+    if (c.name.compare(name) == 0)
+      return &c;
   }
   return nullptr;
 }

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -508,8 +508,6 @@ struct Ctx {
   std::atomic<bool> hasSympart{false};
   // True if there are TLS IE relocations. Set DF_STATIC_TLS if -shared.
   std::atomic<bool> hasTlsIe{false};
-  // True if we need to reserve two .got entries for local-dynamic TLS model.
-  std::atomic<bool> needsTlsLd{false};
 
   void reset();
 

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -106,7 +106,6 @@ void Ctx::reset() {
   whyExtractRecords.clear();
   backwardReferences.clear();
   hasSympart.store(false, std::memory_order_relaxed);
-  needsTlsLd.store(false, std::memory_order_relaxed);
 }
 
 llvm::raw_fd_ostream Ctx::openAuxiliaryFile(llvm::StringRef filename,

--- a/lld/ELF/OutputSections.h
+++ b/lld/ELF/OutputSections.h
@@ -75,9 +75,6 @@ public:
   // Sections accessed using PCC on CHERI architectures.
   std::atomic<bool> cheriPcc{false};
 
-  // This section is the first section after the end of a relro segment.
-  bool relroEnd = false;
-
   void recordSection(InputSectionBase *isec);
   void commitSection(InputSection *isec);
   void finalizeInputSections();

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1926,7 +1926,6 @@ void elf::postScanRelocations() {
           const_cast<SymbolCompartAux &>(aux).setFlags(NEEDS_COPY);
           sym.needsCopyAny = true;
           if (config->emachine == EM_PPC) {
-            // XXXJHB: This would need to be per-compartment
             // PPC32 canonical PLT entries are at the beginning of .glink
             cast<Defined>(sym).value = c.plt->headerSize;
             c.plt->headerSize += 16;

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1472,7 +1472,7 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
     }
     if (expr == R_TLSLD_HINT)
       return 1;
-    ctx.needsTlsLd.store(true, std::memory_order_relaxed);
+    c.needsTlsLd.store(true, std::memory_order_relaxed);
     sec->addReloc({expr, type, offset, addend, &sym});
     return 1;
   }
@@ -2011,8 +2011,8 @@ void elf::postScanRelocations() {
     }
   };
 
-  if (ctx.needsTlsLd.load(std::memory_order_relaxed)) {
-    for (Compartment &c : compartments) {
+  for (Compartment &c : compartments) {
+    if (c.needsTlsLd.load(std::memory_order_relaxed)) {
       GotSection *got = c.got.get();
       if (got->addTlsIndex()) {
         static Undefined dummy(nullptr, "", STB_LOCAL, 0, 0);

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1403,13 +1403,14 @@ static unsigned handleMipsTlsRelocation(RelType type, Symbol &sym,
 static unsigned handleTlsRelocation(RelType type, Symbol &sym,
                                     InputSectionBase *sec, uint64_t offset,
                                     int64_t addend, RelExpr expr) {
+  Compartment &c = sec->getCompartment();
   bool isTgot =
       oneof<R_TGOT, R_TGOT_TP, R_TGOT_GOT, R_TGOT_GOT_PC, R_TGOT_TLSDESC,
             R_TGOT_TLSDESC_CALL, R_TGOT_TLSGD_PC>(expr);
 
   if (oneof<R_TPREL, R_TPREL_NEG, R_TGOT, R_TGOT_TP>(expr)) {
     if (isTgot)
-      sym.setFlags(sec->getCompartment(), NEEDS_TGOT);
+      sym.setFlags(c, NEEDS_TGOT);
 
     if (config->shared) {
       errorOrWarn("relocation " + toString(type) + " against " + toString(sym) +
@@ -1424,16 +1425,16 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
     return handleMipsTlsRelocation(type, sym, *sec, offset, addend, expr);
 
   if (isTgot)
-    sym.setFlags(sec->getCompartment(), NEEDS_TGOT);
+    sym.setFlags(c, NEEDS_TGOT);
 
   if (oneof<R_AARCH64_TLSDESC_PAGE, R_TLSDESC, R_TLSDESC_CALL, R_TLSDESC_PC,
             R_TLSDESC_GOTPLT, R_TGOT_TLSDESC, R_TGOT_TLSDESC_CALL>(expr) &&
       config->shared) {
     if (!oneof<R_TLSDESC_CALL, R_TGOT_TLSDESC_CALL>(expr)) {
       if (isTgot)
-        sym.setFlags(sec->getCompartment(), NEEDS_TGOT_TLSDESC);
+        sym.setFlags(c, NEEDS_TGOT_TLSDESC);
       else
-        sym.setFlags(sec->getCompartment(), NEEDS_TLSDESC);
+        sym.setFlags(c, NEEDS_TLSDESC);
       sec->addReloc({expr, type, offset, addend, &sym});
     }
     return 1;
@@ -1487,7 +1488,7 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
   // Local-Dynamic sequence where offset of tls variable relative to dynamic
   // thread pointer is stored in the got. This cannot be relaxed to Local-Exec.
   if (expr == R_TLSLD_GOT_OFF) {
-    sym.setFlags(sec->getCompartment(), NEEDS_GOT_DTPREL);
+    sym.setFlags(c, NEEDS_GOT_DTPREL);
     sec->addReloc({expr, type, offset, addend, &sym});
     return 1;
   }
@@ -1498,9 +1499,9 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
             R_LOONGARCH_TLSGD_PAGE_PC>(expr)) {
     if (!toExecRelax) {
       if (isTgot)
-        sym.setFlags(sec->getCompartment(), NEEDS_TGOT_TLSGD);
+        sym.setFlags(c, NEEDS_TGOT_TLSGD);
       else
-        sym.setFlags(sec->getCompartment(), NEEDS_TLSGD);
+        sym.setFlags(c, NEEDS_TLSGD);
       sec->addReloc({expr, type, offset, addend, &sym});
       return 1;
     }
@@ -1511,10 +1512,10 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
     if (sym.isPreemptible && !isTgot) {
       RelExpr relaxExpr;
       if (isTgot) {
-        sym.setFlags(sec->getCompartment(), NEEDS_TGOT_GOT);
+        sym.setFlags(c, NEEDS_TGOT_GOT);
         relaxExpr = R_RELAX_TGOT_TLS_GD_TO_IE;
       } else {
-        sym.setFlags(sec->getCompartment(), NEEDS_TLSIE);
+        sym.setFlags(c, NEEDS_TLSIE);
         relaxExpr = R_RELAX_TLS_GD_TO_IE;
       }
       sec->addReloc(
@@ -1547,9 +1548,9 @@ static unsigned handleTlsRelocation(RelType type, Symbol &sym,
       sec->addReloc({relaxExpr, type, offset, addend, &sym});
     } else if (expr != R_TLSIE_HINT) {
       if (isTgot)
-        sym.setFlags(sec->getCompartment(), NEEDS_TGOT_GOT);
+        sym.setFlags(c, NEEDS_TGOT_GOT);
       else
-        sym.setFlags(sec->getCompartment(), NEEDS_TLSIE);
+        sym.setFlags(c, NEEDS_TLSIE);
       // R_GOT needs a relative relocation for PIC on i386 and Hexagon.
       if (expr == R_GOT && config->isPic && !target->usesOnlyLowPageBits(type))
         addRelativeReloc<true>(*sec, offset, sym, addend, expr, type);

--- a/lld/ELF/Symbols.h
+++ b/lld/ELF/Symbols.h
@@ -78,7 +78,7 @@ struct SymbolAux {
 
 LLVM_LIBRARY_VISIBILITY extern SmallVector<SymbolAux, 0> symAux;
 
-// Per-compartment data stored for each symbol.  Since each compartment has a
+// Per-compartment data stored for each symbol.  Since each compartment has
 // separate GOTs, this holds fields related to GOT and PLT entries.
 struct SymbolCompartAux {
   SymbolCompartAux() : isInIplt(false), gotInIgot(false) {}

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -1387,6 +1387,25 @@ struct InStruct {
 
 LLVM_LIBRARY_VISIBILITY extern InStruct in;
 
+template <typename T> class MovableAtomic : public std::atomic<T> {
+public:
+  MovableAtomic() : std::atomic<T>() {}
+
+  MovableAtomic(T desired) : std::atomic<T>(desired) {}
+
+  MovableAtomic(MovableAtomic &&other) : std::atomic<T>() {
+    *this = std::forward<MovableAtomic>(other);
+  }
+
+  MovableAtomic &operator=(MovableAtomic &&other) {
+    if (this != &other) {
+      this->store(other.exchange(T{}, std::memory_order_relaxed),
+                  std::memory_order_relaxed);
+    }
+    return *this;
+  }
+};
+
 struct Compartment {
   StringRef name;
   unsigned nameIndex;
@@ -1404,6 +1423,9 @@ struct Compartment {
   std::unique_ptr<PltSection> plt;
   std::unique_ptr<IpltSection> iplt;
   std::unique_ptr<RelocationBaseSection> relaPlt;
+
+  // True if we need to reserve two .got entries for local-dynamic TLS model.
+  MovableAtomic<bool> needsTlsLd{false};
 
   SmallVector<PhdrEntry *, 1> phdrs;
   PhdrEntry *relRo;

--- a/lld/ELF/Target.cpp
+++ b/lld/ELF/Target.cpp
@@ -192,7 +192,3 @@ uint64_t TargetInfo::getImageBase() const {
     return *config->imageBase;
   return config->isPic ? 0 : defaultImageBase;
 }
-void lld::elf::TargetInfo::relocateNoSym(uint8_t *loc, RelType type,
-                                         uint64_t val) const {
-  relocate(loc, Relocation{R_NONE, type, 0, 0, nullptr}, val);
-}

--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -92,7 +92,9 @@ public:
 
   virtual void relocate(uint8_t *loc, const Relocation &rel,
                         uint64_t val) const = 0;
-  void relocateNoSym(uint8_t *loc, RelType type, uint64_t val) const;
+  void relocateNoSym(uint8_t *loc, RelType type, uint64_t val) const {
+    relocate(loc, Relocation{R_NONE, type, 0, 0, nullptr}, val);
+  }
   virtual void relocateAlloc(InputSectionBase &sec, uint8_t *buf) const;
 
   // Do a linker relaxation pass and return true if we changed something.

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -2727,7 +2727,6 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
   for (Compartment &c : compartments)
     c.relRo = make<PhdrEntry>(PT_GNU_RELRO, PF_R);
 
-  PhdrEntry *relRo = nullptr;
   bool inRelroPhdr = false;
   lastCompartment = nullptr;
   DenseSet<OutputSection *> relroEnd;
@@ -2735,22 +2734,20 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
     if (sec->partition != partNo || !needsPtLoad(sec))
       continue;
     Compartment &c = sec->getCompartment();
-    if (&c != lastCompartment) {
-      if (inRelroPhdr) {
-        inRelroPhdr = false;
-        relroEnd.insert(sec);
-      }
-      lastCompartment = &c;
-      relRo = c.relRo;
+    if (&c != lastCompartment && inRelroPhdr) {
+      inRelroPhdr = false;
+      relroEnd.insert(sec);
     }
+    lastCompartment = &c;
     // Treat a CHERI PCC padding section as relro if it is preceded by a relro
     // section.
     if (isRelroSection(sec) ||
         (c.pccPadding && inRelroPhdr && sec == c.pccPadding->getParent())) {
-      if (inRelroPhdr || !relRo->firstSec) {
+      if (!c.relRo->firstSec)
         inRelroPhdr = true;
-        relRo->add(sec);
-      } else
+      if (inRelroPhdr)
+        c.relRo->add(sec);
+      else
         error("section: " + sec->name + " is not contiguous with other relro" +
               " sections");
     } else if (inRelroPhdr) {

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -477,10 +477,10 @@ template <class ELFT> void elf::createSyntheticSections() {
     in.mipsGot = std::make_unique<MipsGotSection>();
     add(*in.mipsGot);
   } else {
-    for (Compartment &compart : compartments) {
-      compart.got = std::make_unique<GotSection>();
-      compart.got->compartment = compart.getNumber();
-      add(*compart.got);
+    for (Compartment &c : compartments) {
+      c.got = std::make_unique<GotSection>();
+      c.got->compartment = c.getNumber();
+      add(*c.got);
     }
   }
 
@@ -498,16 +498,16 @@ template <class ELFT> void elf::createSyntheticSections() {
     add(*in.ppc64LongBranchTarget);
   }
 
-  for (Compartment &compart : compartments) {
-    compart.gotPlt = std::make_unique<GotPltSection>();
-    compart.gotPlt->compartment = compart.getNumber();
-    add(*compart.gotPlt);
-    compart.igotPlt = std::make_unique<IgotPltSection>();
-    compart.igotPlt->compartment = compart.getNumber();
-    add(*compart.igotPlt);
-    compart.tgot = std::make_unique<TgotSection>();
-    compart.tgot->compartment = compart.getNumber();
-    add(*compart.tgot);
+  for (Compartment &c : compartments) {
+    c.gotPlt = std::make_unique<GotPltSection>();
+    c.gotPlt->compartment = c.getNumber();
+    add(*c.gotPlt);
+    c.igotPlt = std::make_unique<IgotPltSection>();
+    c.igotPlt->compartment = c.getNumber();
+    add(*c.igotPlt);
+    c.tgot = std::make_unique<TgotSection>();
+    c.tgot->compartment = c.getNumber();
+    add(*c.tgot);
   }
 
   if (config->emachine == EM_ARM) {
@@ -531,12 +531,12 @@ template <class ELFT> void elf::createSyntheticSections() {
 
   // We always need to add rel[a].plt to output if it has entries.
   // Even for static linking it can contain R_[*]_IRELATIVE relocations.
-  for (Compartment &compart : compartments) {
-    compart.relaPlt = std::make_unique<RelocationSection<ELFT>>(
+  for (Compartment &c : compartments) {
+    c.relaPlt = std::make_unique<RelocationSection<ELFT>>(
         config->isRela ? ".rela.plt" : ".rel.plt", /*sort=*/false,
         /*threadCount=*/1);
-    compart.relaPlt->compartment = compart.getNumber();
-    add(*compart.relaPlt);
+    c.relaPlt->compartment = c.getNumber();
+    add(*c.relaPlt);
   }
 
   // The relaIplt immediately follows .rel[a].dyn to ensure that the IRelative
@@ -568,23 +568,23 @@ template <class ELFT> void elf::createSyntheticSections() {
     add(*in.ibtPlt);
   }
 
-  for (Compartment &compart : compartments) {
+  for (Compartment &c : compartments) {
     if (config->emachine == EM_PPC)
-      compart.plt = std::make_unique<PPC32GlinkSection>();
+      c.plt = std::make_unique<PPC32GlinkSection>();
     else
-      compart.plt = std::make_unique<PltSection>();
-    compart.plt->compartment = compart.getNumber();
-    add(*compart.plt);
-    compart.iplt = std::make_unique<IpltSection>();
-    compart.iplt->compartment = compart.getNumber();
-    add(*compart.iplt);
+      c.plt = std::make_unique<PltSection>();
+    c.plt->compartment = c.getNumber();
+    add(*c.plt);
+    c.iplt = std::make_unique<IpltSection>();
+    c.iplt->compartment = c.getNumber();
+    add(*c.iplt);
   }
 
   if (config->isCheriAbi && needsCheriPccSegment()) {
-    for (Compartment &compart : compartments) {
-      compart.pccPadding = std::make_unique<CheriPccPaddingSection>();
-      compart.pccPadding->compartment = compart.getNumber();
-      add(*compart.pccPadding);
+    for (Compartment &c : compartments) {
+      c.pccPadding = std::make_unique<CheriPccPaddingSection>();
+      c.pccPadding->compartment = c.getNumber();
+      add(*c.pccPadding);
     }
   }
 
@@ -2724,8 +2724,8 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
   // read-only by dynamic linker after processing relocations.
   // Current dynamic loaders only support one PT_GNU_RELRO PHDR, give
   // an error message if more than one PT_GNU_RELRO PHDR is required.
-  for (Compartment &compart : compartments)
-    compart.relRo = make<PhdrEntry>(PT_GNU_RELRO, PF_R);
+  for (Compartment &c : compartments)
+    c.relRo = make<PhdrEntry>(PT_GNU_RELRO, PF_R);
 
   PhdrEntry *relRo = nullptr;
   bool inRelroPhdr = false;
@@ -2760,8 +2760,8 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
 
   // Determine the sections PCC should cover for each compartment.
   if (config->isCheriAbi && needsCheriPccSegment()) {
-    for (Compartment &compart : compartments)
-      compart.cheriBounds = make<PhdrEntry>(PT_CHERI_PCC, PF_R | PF_X);
+    for (Compartment &c : compartments)
+      c.cheriBounds = make<PhdrEntry>(PT_CHERI_PCC, PF_R | PF_X);
 
     for (OutputSection *sec : outputSections) {
       if (sec->partition != partNo || !needsPtLoad(sec))
@@ -2843,9 +2843,9 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
 
   // Add entries for .tgot.
   PhdrEntry *tgotHdr = make<PhdrEntry>(PT_CHERI_TGOT, PF_R);
-  for (Compartment &compart : compartments) {
-    if (compart.tgot->isNeeded()) {
-      OutputSection *sec = compart.tgot->getParent();
+  for (Compartment &c : compartments) {
+    if (c.tgot->isNeeded()) {
+      OutputSection *sec = c.tgot->getParent();
       tgotHdr->add(sec);
     }
   }
@@ -2856,23 +2856,23 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
   if (OutputSection *sec = part.dynamic->getParent())
     addHdr(PT_DYNAMIC, sec->getPhdrFlags())->add(sec);
 
-  for (Compartment &compart : compartments) {
-    if (compart.isDefault())
+  for (Compartment &c : compartments) {
+    if (c.isDefault())
       continue;
-    if (compart.phdrs.empty())
-      error("no output sections for compartment " + compart.name);
-    for (PhdrEntry *phdr : compart.phdrs)
+    if (c.phdrs.empty())
+      error("no output sections for compartment " + c.name);
+    for (PhdrEntry *phdr : c.phdrs)
       ret.push_back(phdr);
   }
 
-  for (Compartment &compart : compartments)
-    if (compart.relRo->firstSec)
-      ret.push_back(compart.relRo);
+  for (Compartment &c : compartments)
+    if (c.relRo->firstSec)
+      ret.push_back(c.relRo);
 
-  for (Compartment &compart : compartments) {
-    if (compart.cheriBounds) {
-      if (compart.cheriBounds->firstSec)
-        ret.push_back(compart.cheriBounds);
+  for (Compartment &c : compartments) {
+    if (c.cheriBounds) {
+      if (c.cheriBounds->firstSec)
+        ret.push_back(c.cheriBounds);
     }
   }
 

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -2772,8 +2772,6 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
     }
   }
 
-  lastCompartment = nullptr;
-  relRo = nullptr;
   for (OutputSection *sec : outputSections) {
     if (!needsPtLoad(sec))
       continue;
@@ -2788,12 +2786,6 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
       if (isMain && sec->partition == 255)
         addHdr(PT_LOAD, computeFlags(sec->getPhdrFlags()))->add(sec);
       continue;
-    }
-
-    Compartment &c = sec->getCompartment();
-    if (&c != lastCompartment) {
-      lastCompartment = &c;
-      relRo = c.relRo;
     }
 
     // Segments are contiguous memory regions that has the same attributes
@@ -2820,7 +2812,8 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
     uint64_t newFlags = computeFlags(sec->getPhdrFlags());
     bool sameLMARegion =
         load && !sec->lmaExpr && sec->lmaRegion == load->firstSec->lmaRegion;
-    if (!(load && newFlags == flags && sec != relRo->firstSec &&
+    const Compartment &c = sec->getCompartment();
+    if (!(load && newFlags == flags && sec != c.relRo->firstSec &&
           !sec->relroEnd && sec->memRegion == load->firstSec->memRegion &&
           ((load->firstSec->flags & SHF_TLS) || !(sec->flags & SHF_TLS)) &&
           (sameLMARegion || load->lastSec == Out::programHeaders) &&

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -2730,6 +2730,7 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
   PhdrEntry *relRo = nullptr;
   bool inRelroPhdr = false;
   lastCompartment = nullptr;
+  DenseSet<OutputSection *> relroEnd;
   for (OutputSection *sec : outputSections) {
     if (sec->partition != partNo || !needsPtLoad(sec))
       continue;
@@ -2737,7 +2738,7 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
     if (&c != lastCompartment) {
       if (inRelroPhdr) {
         inRelroPhdr = false;
-        sec->relroEnd = true;
+        relroEnd.insert(sec);
       }
       lastCompartment = &c;
       relRo = c.relRo;
@@ -2754,7 +2755,7 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
               " sections");
     } else if (inRelroPhdr) {
       inRelroPhdr = false;
-      sec->relroEnd = true;
+      relroEnd.insert(sec);
     }
   }
 
@@ -2814,7 +2815,8 @@ SmallVector<PhdrEntry *, 0> Writer<ELFT>::createPhdrs(Partition &part) {
         load && !sec->lmaExpr && sec->lmaRegion == load->firstSec->lmaRegion;
     const Compartment &c = sec->getCompartment();
     if (!(load && newFlags == flags && sec != c.relRo->firstSec &&
-          !sec->relroEnd && sec->memRegion == load->firstSec->memRegion &&
+          !relroEnd.contains(sec) &&
+          sec->memRegion == load->firstSec->memRegion &&
           ((load->firstSec->flags & SHF_TLS) || !(sec->flags & SHF_TLS)) &&
           (sameLMARegion || load->lastSec == Out::programHeaders) &&
           (script->hasSectionsCommand || sec->type == SHT_NOBITS ||

--- a/lld/ELF/Writer.h
+++ b/lld/ELF/Writer.h
@@ -57,7 +57,6 @@ uint8_t getMipsIsaExt(uint64_t oldExt, llvm::StringRef oldFile, uint64_t newExt,
                       llvm::StringRef newFile);
 void checkMipsShlibCompatible(InputFile *f, uint64_t shlibCheriFlags,
                               uint64_t targetCheriFlags);
-bool isRelroSection(StringRef name);
 bool isRelroSection(const OutputSection *sec, bool ignoreZRelro = false);
 
 bool isMipsN32Abi(const InputFile *f);


### PR DESCRIPTION
See commit messages for explanations, each fixup should be self-contained and simple to review (with perhaps the odd exception). Verified that git rebase --autosquash doesn't hit any conflicts, so once merged we can just immediately squash them. Reduces the diff to my alternative-history c18n_policy-jrtc27 branch to nothing.
