### PR TITLE
[CHERI-RISC-V] Add aliases for lly and lgy to llc and lgc.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
@@ -1367,6 +1367,8 @@ def PseudoCLLC : Pseudo<(outs GPCR:$dst), (ins bare_symbol:$src), [],
                         "cllc", "$dst, $src">;
 def : InstAlias<"llc $dst, $src",
                 (PseudoCLLC GPCR:$dst, bare_symbol:$src), 0>;
+def : InstAlias<"lly $dst, $src",
+                (PseudoCLLC YGPR:$dst, bare_symbol:$src), 0>;
 
 def : Pat<(riscv_cllc tglobaladdr:$in), (PseudoCLLC tglobaladdr:$in)>;
 def : Pat<(riscv_cllc tblockaddress:$in), (PseudoCLLC tblockaddress:$in)>;
@@ -1379,6 +1381,8 @@ def PseudoCLGC : Pseudo<(outs GPCR:$dst), (ins bare_symbol:$src), [],
                         "clgc", "$dst, $src">;
 def : InstAlias<"lgc $dst, $src",
                 (PseudoCLGC GPCR:$dst, bare_symbol:$src), 0>;
+def : InstAlias<"lgy $dst, $src",
+                (PseudoCLGC YGPR:$dst, bare_symbol:$src), 0>;
 
 def : Pat<(riscv_clgc tglobaladdr:$in), (PseudoCLGC tglobaladdr:$in)>;
 

--- a/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-capmode.s
+++ b/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-capmode.s
@@ -61,3 +61,16 @@ ly ra, 0(sp)
 # CHECK-32-NEXT: sc cra, 0(csp) # encoding: [0x23,0x30,0x11,0x00]
 # CHECK-64-NEXT: sc cra, 0(csp) # encoding: [0x23,0x40,0x11,0x00]
 sy ra, 0(sp)
+
+## Check that lly and lgy pseudos are handled as expected
+label:
+# CHECK-32: auipcc  cra, %got_pcrel_hi(label) # encoding: [0x97,0bAAAA0000,A,A]
+# CHECK-32: lc cra, %pcrel_lo(.Lpcrel_hi0)(cra) # encoding: [0x83,0xb0,0bAAAA0000,A]
+# CHECK-64: auipcc  cra, %got_pcrel_hi(label) # encoding: [0x97,0bAAAA0000,A,A]
+# CHECK-64: lc      cra, %pcrel_lo(.Lpcrel_hi0)(cra) # encoding: [0x8f,0xa0,0bAAAA0000,A]
+lgy x1, label
+# CHECK-32: auipcc  cra, %pcrel_hi(label) # encoding: [0x97,0bAAAA0000,A,A]
+# CHECK-32: cincoffset cra, cra, %pcrel_lo(.Lpcrel_hi1) # encoding: [0xdb,0x90,0bAAAA0000,A]
+# CHECK-64: auipcc  cra, %pcrel_hi(label) # encoding: [0x97,0bAAAA0000,A,A]
+# CHECK-64: cincoffset cra, cra, %pcrel_lo(.Lpcrel_hi1) # encoding: [0xdb,0x90,0bAAAA0000,A]
+lly x1, label


### PR DESCRIPTION
These are intended to be used instead of lla / lga on RVY.